### PR TITLE
v1.3.0 - Add ID Verification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,4 @@
 
+# Access token for Bearer authentication
+ACCESS_TOKEN=
+

--- a/.manifest.json
+++ b/.manifest.json
@@ -1,17 +1,18 @@
 {
-  "liblabVersion": "2.12.0",
-  "date": "2025-01-29T10:28:54.697Z",
+  "liblabVersion": "2.25.35",
+  "date": "2025-07-14T14:19:42.171Z",
   "config": {
-    "apiId": 1713,
+    "apiId": 2479,
     "sdkName": "signplus",
-    "sdkVersion": "1.2.0",
+    "sdkVersion": "1.3.0",
     "languages": ["python"],
     "auth": ["bearer"],
+    "docs": [],
     "liblabVersion": "2",
     "deliveryMethods": ["zip"],
     "rawConfig": {
       "sdkName": "signplus",
-      "apiVersion": "2.2.0",
+      "apiVersion": "2.3.1",
       "apiName": "signplus-api",
       "specFilePath": "openapi.yaml",
       "languages": ["csharp", "go", "python", "typescript", "java", "php"],
@@ -43,7 +44,7 @@
           "pypiPackageName": "signplus-python",
           "githubRepoName": "signplus-python",
           "ignoreFiles": [],
-          "sdkVersion": "1.2.0",
+          "sdkVersion": "1.3.0",
           "liblabVersion": "2",
           "additionalConstructorParameters": []
         },
@@ -51,7 +52,7 @@
           "githubRepoName": "signplus-java",
           "groupId": "com.alohi",
           "artifactId": "signplus",
-          "sdkVersion": "2.2.0",
+          "sdkVersion": "2.3.0",
           "liblabVersion": "2",
           "developers": [
             {
@@ -71,7 +72,7 @@
           "npmOrg": "alohi",
           "githubRepoName": "signplus-typescript",
           "ignoreFiles": [],
-          "sdkVersion": "2.2.0",
+          "sdkVersion": "2.3.0",
           "liblabVersion": "2",
           "additionalConstructorParameters": []
         },
@@ -79,7 +80,7 @@
           "goModuleName": "github.com/alohihq/signplus-go",
           "githubRepoName": "signplus-go",
           "ignoreFiles": [],
-          "sdkVersion": "1.2.0",
+          "sdkVersion": "1.3.0",
           "liblabVersion": "2",
           "additionalConstructorParameters": []
         },
@@ -87,7 +88,7 @@
           "packageName": "alohi/signplus",
           "githubRepoName": "signplus-php",
           "ignoreFiles": [],
-          "sdkVersion": "2.2.0",
+          "sdkVersion": "2.3.0",
           "liblabVersion": "2",
           "additionalConstructorParameters": []
         },
@@ -95,7 +96,7 @@
           "packageId": "Alohi.Signplus",
           "githubRepoName": "signplus-sharp",
           "ignoreFiles": [],
-          "sdkVersion": "1.2.0",
+          "sdkVersion": "1.3.0",
           "liblabVersion": "2"
         }
       },
@@ -103,28 +104,38 @@
         "githubOrg": "alohihq"
       }
     },
-    "apiVersion": "2.2.0",
+    "liblabConfigVersion": "1.0.0",
+    "apiVersion": "2.3.1",
     "apiName": "signplus-api",
     "specFilePath": "openapi.yaml",
+    "createDocs": false,
     "languageOptions": {
       "csharp": {
-        "packageId": "Alohi.Signplus",
         "githubRepoName": "signplus-sharp",
         "ignoreFiles": [],
         "liblabVersion": "2",
-        "sdkVersion": "1.2.0"
+        "renameIllegalModelProperties": true,
+        "sdkVersion": "1.3.0",
+        "packageId": "Alohi.Signplus"
       },
       "go": {
-        "goModuleName": "github.com/alohihq/signplus-go",
-        "additionalConstructorParameters": [],
         "githubRepoName": "signplus-go",
         "ignoreFiles": [],
         "liblabVersion": "2",
-        "sdkVersion": "1.2.0"
+        "renameIllegalModelProperties": true,
+        "sdkVersion": "1.3.0",
+        "goModuleName": "github.com/alohihq/signplus-go",
+        "additionalConstructorParameters": []
       },
       "java": {
+        "githubRepoName": "signplus-java",
+        "ignoreFiles": [],
+        "liblabVersion": "2",
+        "renameIllegalModelProperties": true,
+        "sdkVersion": "2.3.0",
         "groupId": "com.alohi",
         "artifactId": "signplus",
+        "includeKotlinSnippets": false,
         "developers": [
           {
             "name": "Alohi SA",
@@ -133,44 +144,51 @@
             "organizationUrl": "https://www.alohi.com"
           }
         ],
-        "additionalConstructorParameters": [],
-        "githubRepoName": "signplus-java",
-        "liblabVersion": "2",
-        "sdkVersion": "2.2.0"
+        "additionalConstructorParameters": []
       },
       "python": {
-        "alwaysInitializeOptionals": false,
-        "additionalConstructorParameters": [],
-        "pypiPackageName": "signplus-python",
         "githubRepoName": "signplus-python",
         "ignoreFiles": [],
         "liblabVersion": "2",
-        "sdkVersion": "1.2.0"
+        "renameIllegalModelProperties": true,
+        "sdkVersion": "1.3.0",
+        "alwaysInitializeOptionals": false,
+        "additionalConstructorParameters": [],
+        "pypiPackageName": "signplus-python"
       },
       "php": {
-        "packageName": "alohi/signplus",
-        "additionalConstructorParameters": [],
         "githubRepoName": "signplus-php",
         "ignoreFiles": [],
         "liblabVersion": "2",
-        "sdkVersion": "2.2.0"
+        "renameIllegalModelProperties": true,
+        "sdkVersion": "2.3.0",
+        "additionalConstructorParameters": [],
+        "packageName": "alohi/signplus"
       },
       "typescript": {
-        "bundle": false,
-        "exportClassDefault": false,
-        "httpClient": "axios",
-        "npmName": "signplus-typescript",
-        "npmOrg": "alohi",
-        "additionalConstructorParameters": [],
         "githubRepoName": "signplus-typescript",
         "ignoreFiles": [],
         "liblabVersion": "2",
-        "sdkVersion": "2.2.0",
-        "generateEnumAs": "enum"
+        "renameIllegalModelProperties": true,
+        "sdkVersion": "2.3.0",
+        "additionalConstructorParameters": [],
+        "bundle": false,
+        "denoteCommon": false,
+        "exportClassDefault": false,
+        "generateEnumAs": "enum",
+        "httpClient": "axios",
+        "npmName": "signplus-typescript",
+        "npmOrg": "alohi"
       }
     },
+    "validationsToIgnore": [],
     "publishing": {
-      "githubOrg": "alohihq"
+      "githubOrg": "alohihq",
+      "platform": "github"
+    },
+    "analytics": {
+      "streaming": false,
+      "pagination": false
     },
     "authentication": {
       "access": {
@@ -180,8 +198,6 @@
     "devContainer": false,
     "generateEnv": true,
     "includeOptionalSnippetParameters": true,
-    "inferServiceNames": false,
-    "injectedModels": [],
     "license": {
       "type": "MIT",
       "name": "MIT",
@@ -189,6 +205,7 @@
       "path": "MIT.ejs"
     },
     "responseHeaders": false,
+    "buildAllModels": false,
     "retry": {
       "enabled": true,
       "maxAttempts": 3,
@@ -201,11 +218,12 @@
     },
     "multiTenant": true,
     "includeWatermark": false,
+    "githubRepoName": "signplus-python",
+    "ignoreFiles": [],
+    "renameIllegalModelProperties": true,
     "alwaysInitializeOptionals": false,
     "additionalConstructorParameters": [],
     "pypiPackageName": "signplus-python",
-    "githubRepoName": "signplus-python",
-    "ignoreFiles": [],
     "language": "python",
     "deliveryMethod": "zip",
     "hooks": {
@@ -215,10 +233,11 @@
     "usesFormData": false,
     "environmentVariables": [],
     "fileOutput": "/tmp",
+    "inferServiceNames": false,
     "httpLibrary": {
       "name": "axios",
       "packages": {
-        "axios": "^1.7.9"
+        "axios": "^1.9.0"
       },
       "languages": ["typescript"]
     },
@@ -227,7 +246,8 @@
       "rawQueries": [],
       "queriesData": []
     },
-    "ai": false
+    "ai": false,
+    "specType": "openapi"
   },
   "files": [
     "src/signplus/models/utils/base_model.py",
@@ -244,8 +264,11 @@
     "src/signplus/net/request_chain/__init__.py",
     "src/signplus/net/request_chain/handlers/__init__.py",
     "src/signplus/models/utils/__init__.py",
+    "src/signplus/services/async_/__init__.py",
+    "src/signplus/services/async_/utils/__init__.py",
     "src/signplus/net/transport/request.py",
     "src/signplus/net/transport/response.py",
+    "src/signplus/net/transport/api_error.py",
     "src/signplus/net/transport/request_error.py",
     "src/signplus/sdk.py",
     "src/signplus/net/transport/serializer.py",
@@ -269,10 +292,8 @@
     "src/signplus/net/request_chain/handlers/hook_handler.py",
     "src/signplus/net/request_chain/handlers/retry_handler.py",
     "examples/sample.py",
-    ".env.example",
-    "/examples/.env.example",
     "src/signplus/services/utils/default_headers.py",
-    "./LICENSE",
+    "LICENSE",
     "documentation/models/CreateEnvelopeRequest.md",
     "documentation/models/Envelope.md",
     "documentation/models/CreateEnvelopeFromTemplateRequest.md",
@@ -334,6 +355,11 @@
     "documentation/models/WebhookEvent.md",
     "src/signplus/models/utils/one_of_base_model.py",
     "src/signplus/services/async_/utils/to_async.py",
+    "src/signplus/services/async_/signplus.py",
+    "src/signplus/sdk_async.py",
+    "src/signplus/models/utils/sentinel.py",
+    ".env.example",
+    "examples/.env.example",
     "src/signplus/models/envelope_legality_level.py",
     "src/signplus/models/envelope_flow_type.py",
     "src/signplus/models/envelope_status.py",

--- a/PyPI_README.md
+++ b/PyPI_README.md
@@ -1,4 +1,4 @@
-# Signplus Python SDK 1.2.0<a id="signplus-python-sdk-120"></a>
+# Signplus Python SDK 1.3.0<a id="signplus-python-sdk-130"></a>
 
 Welcome to the Signplus SDK documentation. This guide will help you get started with integrating and using the Signplus SDK in your project.
 
@@ -6,8 +6,8 @@ Welcome to the Signplus SDK documentation. This guide will help you get started 
 
 ## Versions<a id="versions"></a>
 
-- API version: `2.2.0`
-- SDK version: `1.2.0`
+- API version: `2.3.1`
+- SDK version: `1.3.0`
 
 ## About the API<a id="about-the-api"></a>
 
@@ -93,6 +93,27 @@ print(result)
 
 ```
 
+# Async Usage<a id="async-usage"></a>
+
+The SDK includes an Async Client for making asynchronous API requests. This is useful for applications that need non-blocking operations, like web servers or apps with a graphical user interface.
+
+```py
+import asyncio
+from signplus import SignplusAsync
+
+sdk = SignplusAsync(
+    access_token="YOUR_ACCESS_TOKEN",
+    timeout=10000
+)
+
+
+async def main():
+  result = await sdk.signplus.get_envelope(envelope_id="envelope_id")
+  print(result)
+
+asyncio.run(main())
+```
+
 ## Services<a id="services"></a>
 
 The SDK provides various services to interact with the API.
@@ -155,7 +176,7 @@ The SDK includes several models that represent the data structures used in API r
 | Recipient                               |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | RecipientRole                           | Role of the recipient (SIGNER signs the document, RECEIVES_COPY receives a copy of the document, IN_PERSON_SIGNER signs the document in person, SENDER sends the document)                                                                                                                                                                                                                                                                                                                |
 | RecipientVerification                   |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| RecipientVerificationType               | Type of signature verification (SMS sends a code via SMS, PASSCODE requires a code to be entered)                                                                                                                                                                                                                                                                                                                                                                                         |
+| RecipientVerificationType               | Type of verification the recipient must complete before accessing the envelope. - `PASSCODE`: requires a code to be entered. - `SMS`: sends a code via SMS. - `ID_VERIFICATION`: prompts the recipient to complete an automated ID and selfie check.                                                                                                                                                                                                                                      |
 | Page                                    |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | EnvelopeOrderField                      | Field to order envelopes by                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | DynamicField                            |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Signplus Python SDK 1.2.0
+# Signplus Python SDK 1.3.0
 
 Welcome to the Signplus SDK documentation. This guide will help you get started with integrating and using the Signplus SDK in your project.
 
@@ -6,8 +6,8 @@ Welcome to the Signplus SDK documentation. This guide will help you get started 
 
 ## Versions
 
-- API version: `2.2.0`
-- SDK version: `1.2.0`
+- API version: `2.3.1`
+- SDK version: `1.3.0`
 
 ## About the API
 
@@ -22,6 +22,7 @@ Integrate legally-binding electronic signature to your workflow
   - [Access Token Authentication](#access-token-authentication)
 - [Setting a Custom Timeout](#setting-a-custom-timeout)
 - [Sample Usage](#sample-usage)
+- [Async Usage](#async-usage)
 - [Services](#services)
 - [Models](#models)
 - [License](#license)
@@ -93,6 +94,27 @@ print(result)
 
 ```
 
+# Async Usage
+
+The SDK includes an Async Client for making asynchronous API requests. This is useful for applications that need non-blocking operations, like web servers or apps with a graphical user interface.
+
+```py
+import asyncio
+from signplus import SignplusAsync
+
+sdk = SignplusAsync(
+    access_token="YOUR_ACCESS_TOKEN",
+    timeout=10000
+)
+
+
+async def main():
+  result = await sdk.signplus.get_envelope(envelope_id="envelope_id")
+  print(result)
+
+asyncio.run(main())
+```
+
 ## Services
 
 The SDK provides various services to interact with the API.
@@ -155,7 +177,7 @@ The SDK includes several models that represent the data structures used in API r
 | [Recipient](documentation/models/Recipient.md)                                                             |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | [RecipientRole](documentation/models/RecipientRole.md)                                                     | Role of the recipient (SIGNER signs the document, RECEIVES_COPY receives a copy of the document, IN_PERSON_SIGNER signs the document in person, SENDER sends the document)                                                                                                                                                                                                                                                                                                                |
 | [RecipientVerification](documentation/models/RecipientVerification.md)                                     |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| [RecipientVerificationType](documentation/models/RecipientVerificationType.md)                             | Type of signature verification (SMS sends a code via SMS, PASSCODE requires a code to be entered)                                                                                                                                                                                                                                                                                                                                                                                         |
+| [RecipientVerificationType](documentation/models/RecipientVerificationType.md)                             | Type of verification the recipient must complete before accessing the envelope. - `PASSCODE`: requires a code to be entered. - `SMS`: sends a code via SMS. - `ID_VERIFICATION`: prompts the recipient to complete an automated ID and selfie check.                                                                                                                                                                                                                                      |
 | [Page](documentation/models/Page.md)                                                                       |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | [EnvelopeOrderField](documentation/models/EnvelopeOrderField.md)                                           | Field to order envelopes by                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | [DynamicField](documentation/models/DynamicField.md)                                                       |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |

--- a/documentation/models/RecipientVerification.md
+++ b/documentation/models/RecipientVerification.md
@@ -2,7 +2,7 @@
 
 **Properties**
 
-| Name   | Type                      | Required | Description                                                                                       |
-| :----- | :------------------------ | :------- | :------------------------------------------------------------------------------------------------ |
-| type\_ | RecipientVerificationType | ❌       | Type of signature verification (SMS sends a code via SMS, PASSCODE requires a code to be entered) |
-| value  | str                       | ❌       |                                                                                                   |
+| Name   | Type                      | Required | Description                                                                                                                                                                                                                                          |
+| :----- | :------------------------ | :------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| type\_ | RecipientVerificationType | ❌       | Type of verification the recipient must complete before accessing the envelope. - `PASSCODE`: requires a code to be entered. - `SMS`: sends a code via SMS. - `ID_VERIFICATION`: prompts the recipient to complete an automated ID and selfie check. |
+| value  | str                       | ❌       | Required for `PASSCODE` and `SMS` verification. - `PASSCODE`: code required by the recipient to sign the document. - `SMS`: recipient's phone number. - `ID_VERIFICATION`: leave empty.                                                              |

--- a/documentation/models/RecipientVerificationType.md
+++ b/documentation/models/RecipientVerificationType.md
@@ -1,10 +1,11 @@
 # RecipientVerificationType
 
-Type of signature verification (SMS sends a code via SMS, PASSCODE requires a code to be entered)
+Type of verification the recipient must complete before accessing the envelope. - `PASSCODE`: requires a code to be entered. - `SMS`: sends a code via SMS. - `ID_VERIFICATION`: prompts the recipient to complete an automated ID and selfie check.
 
 **Properties**
 
-| Name     | Type | Required | Description |
-| :------- | :--- | :------- | :---------- |
-| SMS      | str  | ✅       | "SMS"       |
-| PASSCODE | str  | ✅       | "PASSCODE"  |
+| Name           | Type | Required | Description       |
+| :------------- | :--- | :------- | :---------------- |
+| SMS            | str  | ✅       | "SMS"             |
+| PASSCODE       | str  | ✅       | "PASSCODE"        |
+| IDVERIFICATION | str  | ✅       | "ID_VERIFICATION" |

--- a/documentation/models/TemplateRecipientRole.md
+++ b/documentation/models/TemplateRecipientRole.md
@@ -9,3 +9,4 @@ Role of the recipient (SIGNER signs the document, RECEIVES_COPY receives a copy 
 | SIGNER         | str  | ✅       | "SIGNER"           |
 | RECEIVESCOPY   | str  | ✅       | "RECEIVES_COPY"    |
 | INPERSONSIGNER | str  | ✅       | "IN_PERSON_SIGNER" |
+| SENDER         | str  | ✅       | "SENDER"           |

--- a/documentation/services/SignplusService.md
+++ b/documentation/services/SignplusService.md
@@ -2,49 +2,51 @@
 
 A list of all methods in the `SignplusService` service. Click on the method name to view detailed information about that method.
 
-| Methods                                                                 | Description                       |
-| :---------------------------------------------------------------------- | :-------------------------------- |
-| [create_envelope](#create_envelope)                                     | Create new envelope               |
-| [create_envelope_from_template](#create_envelope_from_template)         | Create new envelope from template |
-| [list_envelopes](#list_envelopes)                                       | List envelopes                    |
-| [get_envelope](#get_envelope)                                           | Get envelope                      |
-| [delete_envelope](#delete_envelope)                                     | Delete envelope                   |
-| [get_envelope_document](#get_envelope_document)                         | Get envelope document             |
-| [get_envelope_documents](#get_envelope_documents)                       | Get envelope documents            |
-| [add_envelope_document](#add_envelope_document)                         | Add envelope document             |
-| [set_envelope_dynamic_fields](#set_envelope_dynamic_fields)             | Set envelope dynamic fields       |
-| [add_envelope_signing_steps](#add_envelope_signing_steps)               | Add envelope signing steps        |
-| [send_envelope](#send_envelope)                                         | Send envelope for signature       |
-| [duplicate_envelope](#duplicate_envelope)                               | Duplicate envelope                |
-| [void_envelope](#void_envelope)                                         | Void envelope                     |
-| [rename_envelope](#rename_envelope)                                     | Rename envelope                   |
-| [set_envelope_comment](#set_envelope_comment)                           | Set envelope comment              |
-| [set_envelope_notification](#set_envelope_notification)                 | Set envelope notification         |
-| [set_envelope_expiration_date](#set_envelope_expiration_date)           | Set envelope expiration date      |
-| [set_envelope_legality_level](#set_envelope_legality_level)             | Set envelope legality level       |
-| [get_envelope_annotations](#get_envelope_annotations)                   | Get envelope annotations          |
-| [get_envelope_document_annotations](#get_envelope_document_annotations) | Get envelope document annotations |
-| [add_envelope_annotation](#add_envelope_annotation)                     | Add envelope annotation           |
-| [delete_envelope_annotation](#delete_envelope_annotation)               | Delete envelope annotation        |
-| [create_template](#create_template)                                     | Create new template               |
-| [list_templates](#list_templates)                                       | List templates                    |
-| [get_template](#get_template)                                           | Get template                      |
-| [delete_template](#delete_template)                                     | Delete template                   |
-| [duplicate_template](#duplicate_template)                               | Duplicate template                |
-| [add_template_document](#add_template_document)                         | Add template document             |
-| [get_template_document](#get_template_document)                         | Get template document             |
-| [get_template_documents](#get_template_documents)                       | Get template documents            |
-| [add_template_signing_steps](#add_template_signing_steps)               | Add template signing steps        |
-| [rename_template](#rename_template)                                     | Rename template                   |
-| [set_template_comment](#set_template_comment)                           | Set template comment              |
-| [set_template_notification](#set_template_notification)                 | Set template notification         |
-| [get_template_annotations](#get_template_annotations)                   | Get template annotations          |
-| [get_document_template_annotations](#get_document_template_annotations) | Get document template annotations |
-| [add_template_annotation](#add_template_annotation)                     | Add template annotation           |
-| [delete_template_annotation](#delete_template_annotation)               | Delete template annotation        |
-| [create_webhook](#create_webhook)                                       | Create webhook                    |
-| [list_webhooks](#list_webhooks)                                         | List webhooks                     |
-| [delete_webhook](#delete_webhook)                                       | Delete webhook                    |
+| Methods                                                                   | Description                                        |
+| :------------------------------------------------------------------------ | :------------------------------------------------- |
+| [create_envelope](#create_envelope)                                       | Create new envelope                                |
+| [create_envelope_from_template](#create_envelope_from_template)           | Create new envelope from template                  |
+| [list_envelopes](#list_envelopes)                                         | List envelopes                                     |
+| [get_envelope](#get_envelope)                                             | Get envelope                                       |
+| [delete_envelope](#delete_envelope)                                       | Delete envelope                                    |
+| [download_envelope_signed_documents](#download_envelope_signed_documents) | Download signed documents for an envelope          |
+| [download_envelope_certificate](#download_envelope_certificate)           | Download certificate of completion for an envelope |
+| [get_envelope_document](#get_envelope_document)                           | Get envelope document                              |
+| [get_envelope_documents](#get_envelope_documents)                         | Get envelope documents                             |
+| [add_envelope_document](#add_envelope_document)                           | Add envelope document                              |
+| [set_envelope_dynamic_fields](#set_envelope_dynamic_fields)               | Set envelope dynamic fields                        |
+| [add_envelope_signing_steps](#add_envelope_signing_steps)                 | Add envelope signing steps                         |
+| [send_envelope](#send_envelope)                                           | Send envelope for signature                        |
+| [duplicate_envelope](#duplicate_envelope)                                 | Duplicate envelope                                 |
+| [void_envelope](#void_envelope)                                           | Void envelope                                      |
+| [rename_envelope](#rename_envelope)                                       | Rename envelope                                    |
+| [set_envelope_comment](#set_envelope_comment)                             | Set envelope comment                               |
+| [set_envelope_notification](#set_envelope_notification)                   | Set envelope notification                          |
+| [set_envelope_expiration_date](#set_envelope_expiration_date)             | Set envelope expiration date                       |
+| [set_envelope_legality_level](#set_envelope_legality_level)               | Set envelope legality level                        |
+| [get_envelope_annotations](#get_envelope_annotations)                     | Get envelope annotations                           |
+| [get_envelope_document_annotations](#get_envelope_document_annotations)   | Get envelope document annotations                  |
+| [add_envelope_annotation](#add_envelope_annotation)                       | Add envelope annotation                            |
+| [delete_envelope_annotation](#delete_envelope_annotation)                 | Delete envelope annotation                         |
+| [create_template](#create_template)                                       | Create new template                                |
+| [list_templates](#list_templates)                                         | List templates                                     |
+| [get_template](#get_template)                                             | Get template                                       |
+| [delete_template](#delete_template)                                       | Delete template                                    |
+| [duplicate_template](#duplicate_template)                                 | Duplicate template                                 |
+| [add_template_document](#add_template_document)                           | Add template document                              |
+| [get_template_document](#get_template_document)                           | Get template document                              |
+| [get_template_documents](#get_template_documents)                         | Get template documents                             |
+| [add_template_signing_steps](#add_template_signing_steps)                 | Add template signing steps                         |
+| [rename_template](#rename_template)                                       | Rename template                                    |
+| [set_template_comment](#set_template_comment)                             | Set template comment                               |
+| [set_template_notification](#set_template_notification)                   | Set template notification                          |
+| [get_template_annotations](#get_template_annotations)                     | Get template annotations                           |
+| [get_document_template_annotations](#get_document_template_annotations)   | Get document template annotations                  |
+| [add_template_annotation](#add_template_annotation)                       | Add template annotation                            |
+| [delete_template_annotation](#delete_template_annotation)                 | Delete template annotation                         |
+| [create_webhook](#create_webhook)                                         | Create webhook                                     |
+| [list_webhooks](#list_webhooks)                                           | List webhooks                                      |
+| [delete_webhook](#delete_webhook)                                         | Delete webhook                                     |
 
 ## create_envelope
 
@@ -79,7 +81,7 @@ request_body = CreateEnvelopeRequest(
     legality_level="SES",
     expires_at=10,
     comment="comment",
-    sandbox=True
+    sandbox=False
 )
 
 result = sdk.signplus.create_envelope(request_body=request_body)
@@ -174,16 +176,16 @@ request_body = ListEnvelopesRequest(
         "folder_ids"
     ],
     only_root_folder=True,
-    date_from=1,
-    date_to=3,
+    date_from=3,
+    date_to=10,
     uid="uid",
-    first=6,
-    last=8,
+    first=4,
+    last=6,
     after="after",
     before="before",
     order_field="CREATION_DATE",
-    ascending=True,
-    include_trash=True
+    ascending=False,
+    include_trash=False
 )
 
 result = sdk.signplus.list_envelopes(request_body=request_body)
@@ -247,6 +249,74 @@ sdk = Signplus(
 )
 
 result = sdk.signplus.delete_envelope(envelope_id="envelope_id")
+
+print(result)
+```
+
+## download_envelope_signed_documents
+
+Download signed documents for an envelope
+
+- HTTP Method: `GET`
+- Endpoint: `/envelope/{envelope_id}/signed_documents`
+
+**Parameters**
+
+| Name                      | Type | Required | Description                                                             |
+| :------------------------ | :--- | :------- | :---------------------------------------------------------------------- |
+| envelope_id               | str  | ✅       | ID of the envelope                                                      |
+| certificate_of_completion | bool | ❌       | Whether to include the certificate of completion in the downloaded file |
+
+**Return Type**
+
+`any`
+
+**Example Usage Code Snippet**
+
+```python
+from signplus import Signplus
+
+sdk = Signplus(
+    access_token="YOUR_ACCESS_TOKEN",
+    timeout=10000
+)
+
+result = sdk.signplus.download_envelope_signed_documents(
+    envelope_id="envelope_id",
+    certificate_of_completion=True
+)
+
+print(result)
+```
+
+## download_envelope_certificate
+
+Download certificate of completion for an envelope
+
+- HTTP Method: `GET`
+- Endpoint: `/envelope/{envelope_id}/certificate`
+
+**Parameters**
+
+| Name        | Type | Required | Description        |
+| :---------- | :--- | :------- | :----------------- |
+| envelope_id | str  | ✅       | ID of the envelope |
+
+**Return Type**
+
+`any`
+
+**Example Usage Code Snippet**
+
+```python
+from signplus import Signplus
+
+sdk = Signplus(
+    access_token="YOUR_ACCESS_TOKEN",
+    timeout=10000
+)
+
+result = sdk.signplus.download_envelope_certificate(envelope_id="envelope_id")
 
 print(result)
 ```
@@ -673,7 +743,7 @@ sdk = Signplus(
 request_body = EnvelopeNotification(
     subject="subject",
     message="message",
-    reminder_interval=9
+    reminder_interval=4
 )
 
 result = sdk.signplus.set_envelope_notification(
@@ -714,7 +784,7 @@ sdk = Signplus(
 )
 
 request_body = SetEnvelopeExpirationRequest(
-    expires_at=6
+    expires_at=5
 )
 
 result = sdk.signplus.set_envelope_expiration_date(
@@ -866,12 +936,12 @@ sdk = Signplus(
 request_body = AddAnnotationRequest(
     recipient_id="recipient_id",
     document_id="document_id",
-    page=3,
-    x=1.92,
-    y=1.94,
-    width=4.18,
-    height=0.39,
-    required=True,
+    page=10,
+    x=1.01,
+    y=5.72,
+    width=0.07,
+    height=0.94,
+    required=False,
     type_="TEXT",
     signature={
         "id_": "id"
@@ -880,32 +950,32 @@ request_body = AddAnnotationRequest(
         "id_": "id"
     },
     text={
-        "size": 3.33,
-        "color": 9.42,
+        "size": 8.54,
+        "color": 2.58,
         "value": "value",
         "tooltip": "tooltip",
         "dynamic_field_name": "dynamic_field_name",
         "font": {
             "family": "UNKNOWN",
             "italic": True,
-            "bold": True
+            "bold": False
         }
     },
     datetime_={
-        "size": 8.42,
+        "size": 7.66,
         "font": {
             "family": "UNKNOWN",
             "italic": True,
-            "bold": True
+            "bold": False
         },
         "color": "color",
         "auto_fill": False,
         "timezone": "timezone",
-        "timestamp": 7,
+        "timestamp": 0,
         "format": "DMY_NUMERIC_SLASH"
     },
     checkbox={
-        "checked": True,
+        "checked": False,
         "style": "CIRCLE_CHECK"
     }
 )
@@ -1023,12 +1093,12 @@ request_body = ListTemplatesRequest(
     ids=[
         "ids"
     ],
-    first=3,
-    last=1,
+    first=10,
+    last=5,
     after="after",
     before="before",
     order_field="TEMPLATE_ID",
-    ascending=True
+    ascending=False
 )
 
 result = sdk.signplus.list_templates(request_body=request_body)
@@ -1404,7 +1474,7 @@ sdk = Signplus(
 request_body = EnvelopeNotification(
     subject="subject",
     message="message",
-    reminder_interval=9
+    reminder_interval=4
 )
 
 result = sdk.signplus.set_template_notification(
@@ -1515,12 +1585,12 @@ sdk = Signplus(
 request_body = AddAnnotationRequest(
     recipient_id="recipient_id",
     document_id="document_id",
-    page=3,
-    x=1.92,
-    y=1.94,
-    width=4.18,
-    height=0.39,
-    required=True,
+    page=10,
+    x=1.01,
+    y=5.72,
+    width=0.07,
+    height=0.94,
+    required=False,
     type_="TEXT",
     signature={
         "id_": "id"
@@ -1529,32 +1599,32 @@ request_body = AddAnnotationRequest(
         "id_": "id"
     },
     text={
-        "size": 3.33,
-        "color": 9.42,
+        "size": 8.54,
+        "color": 2.58,
         "value": "value",
         "tooltip": "tooltip",
         "dynamic_field_name": "dynamic_field_name",
         "font": {
             "family": "UNKNOWN",
             "italic": True,
-            "bold": True
+            "bold": False
         }
     },
     datetime_={
-        "size": 8.42,
+        "size": 7.66,
         "font": {
             "family": "UNKNOWN",
             "italic": True,
-            "bold": True
+            "bold": False
         },
         "color": "color",
         "auto_fill": False,
         "timezone": "timezone",
-        "timestamp": 7,
+        "timestamp": 0,
         "format": "DMY_NUMERIC_SLASH"
     },
     checkbox={
-        "checked": True,
+        "checked": False,
         "style": "CIRCLE_CHECK"
     }
 )

--- a/examples/.env.example
+++ b/examples/.env.example
@@ -1,1 +1,4 @@
 
+# Access token for Bearer authentication
+ACCESS_TOKEN=
+

--- a/examples/install.cmd
+++ b/examples/install.cmd
@@ -2,4 +2,4 @@ python -m venv .venv
 call .venv\Scripts\activate
 pip install build
 python -m build --outdir dist ..\
-pip install dist\signplus_python-1.2.0-py3-none-any.whl --force-reinstall
+pip install dist\signplus_python-1.3.0-py3-none-any.whl --force-reinstall

--- a/examples/install.sh
+++ b/examples/install.sh
@@ -2,4 +2,4 @@ python -m venv .venv
 . .venv/bin/activate
 pip install build
 python -m build --outdir dist ../
-pip install dist/signplus_python-1.2.0-py3-none-any.whl --force-reinstall
+pip install dist/signplus_python-1.3.0-py3-none-any.whl --force-reinstall

--- a/install.cmd
+++ b/install.cmd
@@ -15,7 +15,7 @@ if "%USE_VENV%"=="1" (
 
 pip install build
 python -m build --outdir dist .
-pip install dist\signplus_python-1.2.0-py3-none-any.whl --force-reinstall
+pip install dist\signplus_python-1.3.0-py3-none-any.whl --force-reinstall
 
 if "%USE_VENV%"=="1" (
     deactivate

--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ fi
 
 pip install build
 python -m build --outdir dist .
-pip install dist/signplus_python-1.2.0-py3-none-any.whl --force-reinstall
+pip install dist/signplus_python-1.3.0-py3-none-any.whl --force-reinstall
 
 if [ "$USE_VENV" -eq 1 ]; then
     deactivate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "signplus-python"
-version = "1.2.0"
+version = "1.3.0"
 license = { text = "MIT" }
 description = """Integrate legally-binding electronic signature to your workflow"""
 readme = "PyPI_README.md"

--- a/src/signplus/__init__.py
+++ b/src/signplus/__init__.py
@@ -1,2 +1,3 @@
 from .sdk import Signplus
+from .sdk_async import SignplusAsync
 from .net.environment import Environment

--- a/src/signplus/models/add_annotation_request.py
+++ b/src/signplus/models/add_annotation_request.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from .utils.json_map import JsonMap
 from .utils.base_model import BaseModel
+from .utils.sentinel import SENTINEL
 from .annotation_type import AnnotationType
 from .annotation_signature import AnnotationSignature
 from .annotation_initials import AnnotationInitials
@@ -52,13 +53,13 @@ class AddAnnotationRequest(BaseModel):
         width: float,
         height: float,
         type_: AnnotationType,
-        recipient_id: str = None,
-        required: bool = None,
-        signature: AnnotationSignature = None,
-        initials: AnnotationInitials = None,
-        text: AnnotationText = None,
-        datetime_: AnnotationDateTime = None,
-        checkbox: AnnotationCheckbox = None,
+        recipient_id: str = SENTINEL,
+        required: bool = SENTINEL,
+        signature: AnnotationSignature = SENTINEL,
+        initials: AnnotationInitials = SENTINEL,
+        text: AnnotationText = SENTINEL,
+        datetime_: AnnotationDateTime = SENTINEL,
+        checkbox: AnnotationCheckbox = SENTINEL,
         **kwargs,
     ):
         """AddAnnotationRequest
@@ -92,7 +93,7 @@ class AddAnnotationRequest(BaseModel):
         :param checkbox: Checkbox annotation (null if annotation is not a checkbox), defaults to None
         :type checkbox: AnnotationCheckbox, optional
         """
-        if recipient_id is not None:
+        if recipient_id is not SENTINEL:
             self.recipient_id = recipient_id
         self.document_id = document_id
         self.page = page
@@ -100,17 +101,17 @@ class AddAnnotationRequest(BaseModel):
         self.y = y
         self.width = width
         self.height = height
-        if required is not None:
+        if required is not SENTINEL:
             self.required = required
         self.type_ = self._enum_matching(type_, AnnotationType.list(), "type_")
-        if signature is not None:
+        if signature is not SENTINEL:
             self.signature = self._define_object(signature, AnnotationSignature)
-        if initials is not None:
+        if initials is not SENTINEL:
             self.initials = self._define_object(initials, AnnotationInitials)
-        if text is not None:
+        if text is not SENTINEL:
             self.text = self._define_object(text, AnnotationText)
-        if datetime_ is not None:
+        if datetime_ is not SENTINEL:
             self.datetime_ = self._define_object(datetime_, AnnotationDateTime)
-        if checkbox is not None:
+        if checkbox is not SENTINEL:
             self.checkbox = self._define_object(checkbox, AnnotationCheckbox)
         self._kwargs = kwargs

--- a/src/signplus/models/add_envelope_document_request.py
+++ b/src/signplus/models/add_envelope_document_request.py
@@ -1,5 +1,6 @@
 from .utils.json_map import JsonMap
 from .utils.base_model import BaseModel
+from .utils.sentinel import SENTINEL
 
 
 @JsonMap({})
@@ -10,12 +11,12 @@ class AddEnvelopeDocumentRequest(BaseModel):
     :type file: bytes, optional
     """
 
-    def __init__(self, file: bytes = None, **kwargs):
+    def __init__(self, file: bytes = SENTINEL, **kwargs):
         """AddEnvelopeDocumentRequest
 
         :param file: File to upload in binary format, defaults to None
         :type file: bytes, optional
         """
-        if file is not None:
+        if file is not SENTINEL:
             self.file = file
         self._kwargs = kwargs

--- a/src/signplus/models/add_envelope_signing_steps_request.py
+++ b/src/signplus/models/add_envelope_signing_steps_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from typing import List
 from .utils.json_map import JsonMap
 from .utils.base_model import BaseModel
+from .utils.sentinel import SENTINEL
 from .signing_step import SigningStep
 
 
@@ -13,12 +14,12 @@ class AddEnvelopeSigningStepsRequest(BaseModel):
     :type signing_steps: List[SigningStep], optional
     """
 
-    def __init__(self, signing_steps: List[SigningStep] = None, **kwargs):
+    def __init__(self, signing_steps: List[SigningStep] = SENTINEL, **kwargs):
         """AddEnvelopeSigningStepsRequest
 
         :param signing_steps: List of signing steps, defaults to None
         :type signing_steps: List[SigningStep], optional
         """
-        if signing_steps is not None:
+        if signing_steps is not SENTINEL:
             self.signing_steps = self._define_list(signing_steps, SigningStep)
         self._kwargs = kwargs

--- a/src/signplus/models/annotation.py
+++ b/src/signplus/models/annotation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from .utils.json_map import JsonMap
 from .utils.base_model import BaseModel
+from .utils.sentinel import SENTINEL
 from .annotation_type import AnnotationType
 from .annotation_signature import AnnotationSignature
 from .annotation_initials import AnnotationInitials
@@ -47,21 +48,21 @@ class Annotation(BaseModel):
 
     def __init__(
         self,
-        id_: str = None,
-        recipient_id: str = None,
-        document_id: str = None,
-        page: int = None,
-        x: float = None,
-        y: float = None,
-        width: float = None,
-        height: float = None,
-        required: bool = None,
-        type_: AnnotationType = None,
-        signature: AnnotationSignature = None,
-        initials: AnnotationInitials = None,
-        text: AnnotationText = None,
-        datetime_: AnnotationDateTime = None,
-        checkbox: AnnotationCheckbox = None,
+        id_: str = SENTINEL,
+        recipient_id: str = SENTINEL,
+        document_id: str = SENTINEL,
+        page: int = SENTINEL,
+        x: float = SENTINEL,
+        y: float = SENTINEL,
+        width: float = SENTINEL,
+        height: float = SENTINEL,
+        required: bool = SENTINEL,
+        type_: AnnotationType = SENTINEL,
+        signature: AnnotationSignature = SENTINEL,
+        initials: AnnotationInitials = SENTINEL,
+        text: AnnotationText = SENTINEL,
+        datetime_: AnnotationDateTime = SENTINEL,
+        checkbox: AnnotationCheckbox = SENTINEL,
         **kwargs,
     ):
         """Annotation
@@ -97,34 +98,34 @@ class Annotation(BaseModel):
         :param checkbox: Checkbox annotation (null if annotation is not a checkbox), defaults to None
         :type checkbox: AnnotationCheckbox, optional
         """
-        if id_ is not None:
+        if id_ is not SENTINEL:
             self.id_ = id_
-        if recipient_id is not None:
+        if recipient_id is not SENTINEL:
             self.recipient_id = recipient_id
-        if document_id is not None:
+        if document_id is not SENTINEL:
             self.document_id = document_id
-        if page is not None:
+        if page is not SENTINEL:
             self.page = page
-        if x is not None:
+        if x is not SENTINEL:
             self.x = x
-        if y is not None:
+        if y is not SENTINEL:
             self.y = y
-        if width is not None:
+        if width is not SENTINEL:
             self.width = width
-        if height is not None:
+        if height is not SENTINEL:
             self.height = height
-        if required is not None:
+        if required is not SENTINEL:
             self.required = required
-        if type_ is not None:
+        if type_ is not SENTINEL:
             self.type_ = self._enum_matching(type_, AnnotationType.list(), "type_")
-        if signature is not None:
+        if signature is not SENTINEL:
             self.signature = self._define_object(signature, AnnotationSignature)
-        if initials is not None:
+        if initials is not SENTINEL:
             self.initials = self._define_object(initials, AnnotationInitials)
-        if text is not None:
+        if text is not SENTINEL:
             self.text = self._define_object(text, AnnotationText)
-        if datetime_ is not None:
+        if datetime_ is not SENTINEL:
             self.datetime_ = self._define_object(datetime_, AnnotationDateTime)
-        if checkbox is not None:
+        if checkbox is not SENTINEL:
             self.checkbox = self._define_object(checkbox, AnnotationCheckbox)
         self._kwargs = kwargs

--- a/src/signplus/models/annotation_checkbox.py
+++ b/src/signplus/models/annotation_checkbox.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from .utils.json_map import JsonMap
 from .utils.base_model import BaseModel
+from .utils.sentinel import SENTINEL
 from .annotation_checkbox_style import AnnotationCheckboxStyle
 
 
@@ -15,7 +16,10 @@ class AnnotationCheckbox(BaseModel):
     """
 
     def __init__(
-        self, checked: bool = None, style: AnnotationCheckboxStyle = None, **kwargs
+        self,
+        checked: bool = SENTINEL,
+        style: AnnotationCheckboxStyle = SENTINEL,
+        **kwargs,
     ):
         """Checkbox annotation (null if annotation is not a checkbox)
 
@@ -24,9 +28,9 @@ class AnnotationCheckbox(BaseModel):
         :param style: Style of the checkbox, defaults to None
         :type style: AnnotationCheckboxStyle, optional
         """
-        if checked is not None:
+        if checked is not SENTINEL:
             self.checked = checked
-        if style is not None:
+        if style is not SENTINEL:
             self.style = self._enum_matching(
                 style, AnnotationCheckboxStyle.list(), "style"
             )

--- a/src/signplus/models/annotation_date_time.py
+++ b/src/signplus/models/annotation_date_time.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from .utils.json_map import JsonMap
 from .utils.base_model import BaseModel
+from .utils.sentinel import SENTINEL
 from .annotation_font import AnnotationFont
 from .annotation_date_time_format import AnnotationDateTimeFormat
 
@@ -27,13 +28,13 @@ class AnnotationDateTime(BaseModel):
 
     def __init__(
         self,
-        size: float = None,
-        font: AnnotationFont = None,
-        color: str = None,
-        auto_fill: bool = None,
-        timezone: str = None,
-        timestamp: int = None,
-        format: AnnotationDateTimeFormat = None,
+        size: float = SENTINEL,
+        font: AnnotationFont = SENTINEL,
+        color: str = SENTINEL,
+        auto_fill: bool = SENTINEL,
+        timezone: str = SENTINEL,
+        timestamp: int = SENTINEL,
+        format: AnnotationDateTimeFormat = SENTINEL,
         **kwargs,
     ):
         """Date annotation (null if annotation is not a date)
@@ -53,19 +54,19 @@ class AnnotationDateTime(BaseModel):
         :param format: Format of the date time (DMY_NUMERIC_SLASH is day/month/year with slashes, MDY_NUMERIC_SLASH is month/day/year with slashes, YMD_NUMERIC_SLASH is year/month/day with slashes, DMY_NUMERIC_DASH_SHORT is day/month/year with dashes, DMY_NUMERIC_DASH is day/month/year with dashes, YMD_NUMERIC_DASH is year/month/day with dashes, MDY_TEXT_DASH_SHORT is month/day/year with dashes, MDY_TEXT_SPACE_SHORT is month/day/year with spaces, MDY_TEXT_SPACE is month/day/year with spaces), defaults to None
         :type format: AnnotationDateTimeFormat, optional
         """
-        if size is not None:
+        if size is not SENTINEL:
             self.size = size
-        if font is not None:
+        if font is not SENTINEL:
             self.font = self._define_object(font, AnnotationFont)
-        if color is not None:
+        if color is not SENTINEL:
             self.color = color
-        if auto_fill is not None:
+        if auto_fill is not SENTINEL:
             self.auto_fill = auto_fill
-        if timezone is not None:
+        if timezone is not SENTINEL:
             self.timezone = timezone
-        if timestamp is not None:
+        if timestamp is not SENTINEL:
             self.timestamp = timestamp
-        if format is not None:
+        if format is not SENTINEL:
             self.format = self._enum_matching(
                 format, AnnotationDateTimeFormat.list(), "format"
             )

--- a/src/signplus/models/annotation_font.py
+++ b/src/signplus/models/annotation_font.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from .utils.json_map import JsonMap
 from .utils.base_model import BaseModel
+from .utils.sentinel import SENTINEL
 from .annotation_font_family import AnnotationFontFamily
 
 
@@ -18,9 +19,9 @@ class AnnotationFont(BaseModel):
 
     def __init__(
         self,
-        family: AnnotationFontFamily = None,
-        italic: bool = None,
-        bold: bool = None,
+        family: AnnotationFontFamily = SENTINEL,
+        italic: bool = SENTINEL,
+        bold: bool = SENTINEL,
         **kwargs,
     ):
         """AnnotationFont
@@ -32,12 +33,12 @@ class AnnotationFont(BaseModel):
         :param bold: Whether the text is bold, defaults to None
         :type bold: bool, optional
         """
-        if family is not None:
+        if family is not SENTINEL:
             self.family = self._enum_matching(
                 family, AnnotationFontFamily.list(), "family"
             )
-        if italic is not None:
+        if italic is not SENTINEL:
             self.italic = italic
-        if bold is not None:
+        if bold is not SENTINEL:
             self.bold = bold
         self._kwargs = kwargs

--- a/src/signplus/models/annotation_initials.py
+++ b/src/signplus/models/annotation_initials.py
@@ -1,5 +1,6 @@
 from .utils.json_map import JsonMap
 from .utils.base_model import BaseModel
+from .utils.sentinel import SENTINEL
 
 
 @JsonMap({"id_": "id"})
@@ -10,12 +11,12 @@ class AnnotationInitials(BaseModel):
     :type id_: str, optional
     """
 
-    def __init__(self, id_: str = None, **kwargs):
+    def __init__(self, id_: str = SENTINEL, **kwargs):
         """Initials annotation (null if annotation is not initials)
 
         :param id_: Unique identifier of the annotation initials, defaults to None
         :type id_: str, optional
         """
-        if id_ is not None:
+        if id_ is not SENTINEL:
             self.id_ = id_
         self._kwargs = kwargs

--- a/src/signplus/models/annotation_signature.py
+++ b/src/signplus/models/annotation_signature.py
@@ -1,5 +1,6 @@
 from .utils.json_map import JsonMap
 from .utils.base_model import BaseModel
+from .utils.sentinel import SENTINEL
 
 
 @JsonMap({"id_": "id"})
@@ -10,12 +11,12 @@ class AnnotationSignature(BaseModel):
     :type id_: str, optional
     """
 
-    def __init__(self, id_: str = None, **kwargs):
+    def __init__(self, id_: str = SENTINEL, **kwargs):
         """Signature annotation (null if annotation is not a signature)
 
         :param id_: Unique identifier of the annotation signature, defaults to None
         :type id_: str, optional
         """
-        if id_ is not None:
+        if id_ is not SENTINEL:
             self.id_ = id_
         self._kwargs = kwargs

--- a/src/signplus/models/annotation_text.py
+++ b/src/signplus/models/annotation_text.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from .utils.json_map import JsonMap
 from .utils.base_model import BaseModel
+from .utils.sentinel import SENTINEL
 from .annotation_font import AnnotationFont
 
 
@@ -24,12 +25,12 @@ class AnnotationText(BaseModel):
 
     def __init__(
         self,
-        size: float = None,
-        color: float = None,
-        value: str = None,
-        tooltip: str = None,
-        dynamic_field_name: str = None,
-        font: AnnotationFont = None,
+        size: float = SENTINEL,
+        color: float = SENTINEL,
+        value: str = SENTINEL,
+        tooltip: str = SENTINEL,
+        dynamic_field_name: str = SENTINEL,
+        font: AnnotationFont = SENTINEL,
         **kwargs,
     ):
         """Text annotation (null if annotation is not a text)
@@ -47,16 +48,16 @@ class AnnotationText(BaseModel):
         :param font: font, defaults to None
         :type font: AnnotationFont, optional
         """
-        if size is not None:
+        if size is not SENTINEL:
             self.size = size
-        if color is not None:
+        if color is not SENTINEL:
             self.color = color
-        if value is not None:
+        if value is not SENTINEL:
             self.value = value
-        if tooltip is not None:
+        if tooltip is not SENTINEL:
             self.tooltip = tooltip
-        if dynamic_field_name is not None:
+        if dynamic_field_name is not SENTINEL:
             self.dynamic_field_name = dynamic_field_name
-        if font is not None:
+        if font is not SENTINEL:
             self.font = self._define_object(font, AnnotationFont)
         self._kwargs = kwargs

--- a/src/signplus/models/create_envelope_from_template_request.py
+++ b/src/signplus/models/create_envelope_from_template_request.py
@@ -1,5 +1,6 @@
 from .utils.json_map import JsonMap
 from .utils.base_model import BaseModel
+from .utils.sentinel import SENTINEL
 
 
 @JsonMap({})
@@ -14,7 +15,9 @@ class CreateEnvelopeFromTemplateRequest(BaseModel):
     :type sandbox: bool, optional
     """
 
-    def __init__(self, name: str, comment: str = None, sandbox: bool = None, **kwargs):
+    def __init__(
+        self, name: str, comment: str = SENTINEL, sandbox: bool = SENTINEL, **kwargs
+    ):
         """CreateEnvelopeFromTemplateRequest
 
         :param name: Name of the envelope
@@ -24,9 +27,15 @@ class CreateEnvelopeFromTemplateRequest(BaseModel):
         :param sandbox: Whether the envelope is created in sandbox mode, defaults to None
         :type sandbox: bool, optional
         """
-        self.name = name
-        if comment is not None:
+        self.name = self._define_str(
+            "name",
+            name,
+            pattern="^[a-zA-Z0-9][a-zA-Z0-9 ]*[a-zA-Z0-9]$",
+            min_length=2,
+            max_length=256,
+        )
+        if comment is not SENTINEL:
             self.comment = comment
-        if sandbox is not None:
+        if sandbox is not SENTINEL:
             self.sandbox = sandbox
         self._kwargs = kwargs

--- a/src/signplus/models/create_envelope_request.py
+++ b/src/signplus/models/create_envelope_request.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from .utils.json_map import JsonMap
 from .utils.base_model import BaseModel
+from .utils.sentinel import SENTINEL
 from .envelope_legality_level import EnvelopeLegalityLevel
 
 
@@ -24,9 +25,9 @@ class CreateEnvelopeRequest(BaseModel):
         self,
         name: str,
         legality_level: EnvelopeLegalityLevel,
-        expires_at: int = None,
-        comment: str = None,
-        sandbox: bool = None,
+        expires_at: int = SENTINEL,
+        comment: str = SENTINEL,
+        sandbox: bool = SENTINEL,
         **kwargs,
     ):
         """CreateEnvelopeRequest
@@ -42,14 +43,20 @@ class CreateEnvelopeRequest(BaseModel):
         :param sandbox: Whether the envelope is created in sandbox mode, defaults to None
         :type sandbox: bool, optional
         """
-        self.name = name
+        self.name = self._define_str(
+            "name",
+            name,
+            pattern="^[a-zA-Z0-9][a-zA-Z0-9 ]*[a-zA-Z0-9]$",
+            min_length=2,
+            max_length=256,
+        )
         self.legality_level = self._enum_matching(
             legality_level, EnvelopeLegalityLevel.list(), "legality_level"
         )
-        if expires_at is not None:
+        if expires_at is not SENTINEL:
             self.expires_at = expires_at
-        if comment is not None:
+        if comment is not SENTINEL:
             self.comment = comment
-        if sandbox is not None:
+        if sandbox is not SENTINEL:
             self.sandbox = sandbox
         self._kwargs = kwargs

--- a/src/signplus/models/create_template_request.py
+++ b/src/signplus/models/create_template_request.py
@@ -16,5 +16,11 @@ class CreateTemplateRequest(BaseModel):
         :param name: name
         :type name: str
         """
-        self.name = name
+        self.name = self._define_str(
+            "name",
+            name,
+            pattern="^[a-zA-Z0-9][a-zA-Z0-9 ]*[a-zA-Z0-9]$",
+            min_length=2,
+            max_length=256,
+        )
         self._kwargs = kwargs

--- a/src/signplus/models/document.py
+++ b/src/signplus/models/document.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from typing import List
 from .utils.json_map import JsonMap
 from .utils.base_model import BaseModel
+from .utils.sentinel import SENTINEL
 from .page import Page
 
 
@@ -23,11 +24,11 @@ class Document(BaseModel):
 
     def __init__(
         self,
-        id_: str = None,
-        name: str = None,
-        filename: str = None,
-        page_count: int = None,
-        pages: List[Page] = None,
+        id_: str = SENTINEL,
+        name: str = SENTINEL,
+        filename: str = SENTINEL,
+        page_count: int = SENTINEL,
+        pages: List[Page] = SENTINEL,
         **kwargs,
     ):
         """Document
@@ -43,14 +44,14 @@ class Document(BaseModel):
         :param pages: List of pages in the document, defaults to None
         :type pages: List[Page], optional
         """
-        if id_ is not None:
+        if id_ is not SENTINEL:
             self.id_ = id_
-        if name is not None:
+        if name is not SENTINEL:
             self.name = name
-        if filename is not None:
+        if filename is not SENTINEL:
             self.filename = filename
-        if page_count is not None:
+        if page_count is not SENTINEL:
             self.page_count = page_count
-        if pages is not None:
+        if pages is not SENTINEL:
             self.pages = self._define_list(pages, Page)
         self._kwargs = kwargs

--- a/src/signplus/models/dynamic_field.py
+++ b/src/signplus/models/dynamic_field.py
@@ -1,5 +1,6 @@
 from .utils.json_map import JsonMap
 from .utils.base_model import BaseModel
+from .utils.sentinel import SENTINEL
 
 
 @JsonMap({})
@@ -12,7 +13,7 @@ class DynamicField(BaseModel):
     :type value: str, optional
     """
 
-    def __init__(self, name: str = None, value: str = None, **kwargs):
+    def __init__(self, name: str = SENTINEL, value: str = SENTINEL, **kwargs):
         """DynamicField
 
         :param name: Name of the dynamic field, defaults to None
@@ -20,8 +21,8 @@ class DynamicField(BaseModel):
         :param value: Value of the dynamic field, defaults to None
         :type value: str, optional
         """
-        if name is not None:
+        if name is not SENTINEL:
             self.name = name
-        if value is not None:
+        if value is not SENTINEL:
             self.value = value
         self._kwargs = kwargs

--- a/src/signplus/models/envelope.py
+++ b/src/signplus/models/envelope.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from typing import List
 from .utils.json_map import JsonMap
 from .utils.base_model import BaseModel
+from .utils.sentinel import SENTINEL
 from .envelope_flow_type import EnvelopeFlowType
 from .envelope_legality_level import EnvelopeLegalityLevel
 from .envelope_status import EnvelopeStatus
@@ -48,21 +49,21 @@ class Envelope(BaseModel):
 
     def __init__(
         self,
-        id_: str = None,
-        name: str = None,
-        comment: str = None,
-        pages: int = None,
-        flow_type: EnvelopeFlowType = None,
-        legality_level: EnvelopeLegalityLevel = None,
-        status: EnvelopeStatus = None,
-        created_at: int = None,
-        updated_at: int = None,
-        expires_at: int = None,
-        num_recipients: int = None,
-        is_duplicable: bool = None,
-        signing_steps: List[SigningStep] = None,
-        documents: List[Document] = None,
-        notification: EnvelopeNotification = None,
+        id_: str = SENTINEL,
+        name: str = SENTINEL,
+        comment: str = SENTINEL,
+        pages: int = SENTINEL,
+        flow_type: EnvelopeFlowType = SENTINEL,
+        legality_level: EnvelopeLegalityLevel = SENTINEL,
+        status: EnvelopeStatus = SENTINEL,
+        created_at: int = SENTINEL,
+        updated_at: int = SENTINEL,
+        expires_at: int = SENTINEL,
+        num_recipients: int = SENTINEL,
+        is_duplicable: bool = SENTINEL,
+        signing_steps: List[SigningStep] = SENTINEL,
+        documents: List[Document] = SENTINEL,
+        notification: EnvelopeNotification = SENTINEL,
         **kwargs,
     ):
         """Envelope
@@ -98,38 +99,38 @@ class Envelope(BaseModel):
         :param notification: notification, defaults to None
         :type notification: EnvelopeNotification, optional
         """
-        if id_ is not None:
+        if id_ is not SENTINEL:
             self.id_ = id_
-        if name is not None:
+        if name is not SENTINEL:
             self.name = name
-        if comment is not None:
+        if comment is not SENTINEL:
             self.comment = comment
-        if pages is not None:
+        if pages is not SENTINEL:
             self.pages = pages
-        if flow_type is not None:
+        if flow_type is not SENTINEL:
             self.flow_type = self._enum_matching(
                 flow_type, EnvelopeFlowType.list(), "flow_type"
             )
-        if legality_level is not None:
+        if legality_level is not SENTINEL:
             self.legality_level = self._enum_matching(
                 legality_level, EnvelopeLegalityLevel.list(), "legality_level"
             )
-        if status is not None:
+        if status is not SENTINEL:
             self.status = self._enum_matching(status, EnvelopeStatus.list(), "status")
-        if created_at is not None:
+        if created_at is not SENTINEL:
             self.created_at = created_at
-        if updated_at is not None:
+        if updated_at is not SENTINEL:
             self.updated_at = updated_at
-        if expires_at is not None:
+        if expires_at is not SENTINEL:
             self.expires_at = expires_at
-        if num_recipients is not None:
+        if num_recipients is not SENTINEL:
             self.num_recipients = num_recipients
-        if is_duplicable is not None:
+        if is_duplicable is not SENTINEL:
             self.is_duplicable = is_duplicable
-        if signing_steps is not None:
+        if signing_steps is not SENTINEL:
             self.signing_steps = self._define_list(signing_steps, SigningStep)
-        if documents is not None:
+        if documents is not SENTINEL:
             self.documents = self._define_list(documents, Document)
-        if notification is not None:
+        if notification is not SENTINEL:
             self.notification = self._define_object(notification, EnvelopeNotification)
         self._kwargs = kwargs

--- a/src/signplus/models/envelope_notification.py
+++ b/src/signplus/models/envelope_notification.py
@@ -1,5 +1,6 @@
 from .utils.json_map import JsonMap
 from .utils.base_model import BaseModel
+from .utils.sentinel import SENTINEL
 
 
 @JsonMap({})
@@ -16,9 +17,9 @@ class EnvelopeNotification(BaseModel):
 
     def __init__(
         self,
-        subject: str = None,
-        message: str = None,
-        reminder_interval: int = None,
+        subject: str = SENTINEL,
+        message: str = SENTINEL,
+        reminder_interval: int = SENTINEL,
         **kwargs
     ):
         """EnvelopeNotification
@@ -30,10 +31,10 @@ class EnvelopeNotification(BaseModel):
         :param reminder_interval: Interval in days to send reminder, defaults to None
         :type reminder_interval: int, optional
         """
-        if subject is not None:
+        if subject is not SENTINEL:
             self.subject = subject
-        if message is not None:
+        if message is not SENTINEL:
             self.message = message
-        if reminder_interval is not None:
+        if reminder_interval is not SENTINEL:
             self.reminder_interval = reminder_interval
         self._kwargs = kwargs

--- a/src/signplus/models/list_envelope_document_annotations_response.py
+++ b/src/signplus/models/list_envelope_document_annotations_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from typing import List
 from .utils.json_map import JsonMap
 from .utils.base_model import BaseModel
+from .utils.sentinel import SENTINEL
 from .annotation import Annotation
 
 
@@ -13,12 +14,12 @@ class ListEnvelopeDocumentAnnotationsResponse(BaseModel):
     :type annotations: List[Annotation], optional
     """
 
-    def __init__(self, annotations: List[Annotation] = None, **kwargs):
+    def __init__(self, annotations: List[Annotation] = SENTINEL, **kwargs):
         """ListEnvelopeDocumentAnnotationsResponse
 
         :param annotations: annotations, defaults to None
         :type annotations: List[Annotation], optional
         """
-        if annotations is not None:
+        if annotations is not SENTINEL:
             self.annotations = self._define_list(annotations, Annotation)
         self._kwargs = kwargs

--- a/src/signplus/models/list_envelope_documents_response.py
+++ b/src/signplus/models/list_envelope_documents_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from typing import List
 from .utils.json_map import JsonMap
 from .utils.base_model import BaseModel
+from .utils.sentinel import SENTINEL
 from .document import Document
 
 
@@ -13,12 +14,12 @@ class ListEnvelopeDocumentsResponse(BaseModel):
     :type documents: List[Document], optional
     """
 
-    def __init__(self, documents: List[Document] = None, **kwargs):
+    def __init__(self, documents: List[Document] = SENTINEL, **kwargs):
         """ListEnvelopeDocumentsResponse
 
         :param documents: documents, defaults to None
         :type documents: List[Document], optional
         """
-        if documents is not None:
+        if documents is not SENTINEL:
             self.documents = self._define_list(documents, Document)
         self._kwargs = kwargs

--- a/src/signplus/models/list_envelopes_request.py
+++ b/src/signplus/models/list_envelopes_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from typing import List
 from .utils.json_map import JsonMap
 from .utils.base_model import BaseModel
+from .utils.sentinel import SENTINEL
 from .envelope_status import EnvelopeStatus
 from .envelope_order_field import EnvelopeOrderField
 
@@ -48,23 +49,23 @@ class ListEnvelopesRequest(BaseModel):
 
     def __init__(
         self,
-        name: str = None,
-        tags: List[str] = None,
-        comment: str = None,
-        ids: List[str] = None,
-        statuses: List[EnvelopeStatus] = None,
-        folder_ids: List[str] = None,
-        only_root_folder: bool = None,
-        date_from: int = None,
-        date_to: int = None,
-        uid: str = None,
-        first: int = None,
-        last: int = None,
-        after: str = None,
-        before: str = None,
-        order_field: EnvelopeOrderField = None,
-        ascending: bool = None,
-        include_trash: bool = None,
+        name: str = SENTINEL,
+        tags: List[str] = SENTINEL,
+        comment: str = SENTINEL,
+        ids: List[str] = SENTINEL,
+        statuses: List[EnvelopeStatus] = SENTINEL,
+        folder_ids: List[str] = SENTINEL,
+        only_root_folder: bool = SENTINEL,
+        date_from: int = SENTINEL,
+        date_to: int = SENTINEL,
+        uid: str = SENTINEL,
+        first: int = SENTINEL,
+        last: int = SENTINEL,
+        after: str = SENTINEL,
+        before: str = SENTINEL,
+        order_field: EnvelopeOrderField = SENTINEL,
+        ascending: bool = SENTINEL,
+        include_trash: bool = SENTINEL,
         **kwargs,
     ):
         """ListEnvelopesRequest
@@ -104,40 +105,40 @@ class ListEnvelopesRequest(BaseModel):
         :param include_trash: Whether to include envelopes in the trash, defaults to None
         :type include_trash: bool, optional
         """
-        if name is not None:
+        if name is not SENTINEL:
             self.name = name
-        if tags is not None:
+        if tags is not SENTINEL:
             self.tags = tags
-        if comment is not None:
+        if comment is not SENTINEL:
             self.comment = comment
-        if ids is not None:
+        if ids is not SENTINEL:
             self.ids = ids
-        if statuses is not None:
+        if statuses is not SENTINEL:
             self.statuses = self._define_list(statuses, EnvelopeStatus)
-        if folder_ids is not None:
+        if folder_ids is not SENTINEL:
             self.folder_ids = folder_ids
-        if only_root_folder is not None:
+        if only_root_folder is not SENTINEL:
             self.only_root_folder = only_root_folder
-        if date_from is not None:
+        if date_from is not SENTINEL:
             self.date_from = date_from
-        if date_to is not None:
+        if date_to is not SENTINEL:
             self.date_to = date_to
-        if uid is not None:
+        if uid is not SENTINEL:
             self.uid = uid
-        if first is not None:
+        if first is not SENTINEL:
             self.first = first
-        if last is not None:
+        if last is not SENTINEL:
             self.last = last
-        if after is not None:
+        if after is not SENTINEL:
             self.after = after
-        if before is not None:
+        if before is not SENTINEL:
             self.before = before
-        if order_field is not None:
+        if order_field is not SENTINEL:
             self.order_field = self._enum_matching(
                 order_field, EnvelopeOrderField.list(), "order_field"
             )
-        if ascending is not None:
+        if ascending is not SENTINEL:
             self.ascending = ascending
-        if include_trash is not None:
+        if include_trash is not SENTINEL:
             self.include_trash = include_trash
         self._kwargs = kwargs

--- a/src/signplus/models/list_envelopes_response.py
+++ b/src/signplus/models/list_envelopes_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from typing import List
 from .utils.json_map import JsonMap
 from .utils.base_model import BaseModel
+from .utils.sentinel import SENTINEL
 from .envelope import Envelope
 
 
@@ -19,9 +20,9 @@ class ListEnvelopesResponse(BaseModel):
 
     def __init__(
         self,
-        has_next_page: bool = None,
-        has_previous_page: bool = None,
-        envelopes: List[Envelope] = None,
+        has_next_page: bool = SENTINEL,
+        has_previous_page: bool = SENTINEL,
+        envelopes: List[Envelope] = SENTINEL,
         **kwargs,
     ):
         """ListEnvelopesResponse
@@ -33,10 +34,10 @@ class ListEnvelopesResponse(BaseModel):
         :param envelopes: envelopes, defaults to None
         :type envelopes: List[Envelope], optional
         """
-        if has_next_page is not None:
+        if has_next_page is not SENTINEL:
             self.has_next_page = has_next_page
-        if has_previous_page is not None:
+        if has_previous_page is not SENTINEL:
             self.has_previous_page = has_previous_page
-        if envelopes is not None:
+        if envelopes is not SENTINEL:
             self.envelopes = self._define_list(envelopes, Envelope)
         self._kwargs = kwargs

--- a/src/signplus/models/list_template_annotations_response.py
+++ b/src/signplus/models/list_template_annotations_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from typing import List
 from .utils.json_map import JsonMap
 from .utils.base_model import BaseModel
+from .utils.sentinel import SENTINEL
 from .annotation import Annotation
 
 
@@ -13,12 +14,12 @@ class ListTemplateAnnotationsResponse(BaseModel):
     :type annotations: List[Annotation], optional
     """
 
-    def __init__(self, annotations: List[Annotation] = None, **kwargs):
+    def __init__(self, annotations: List[Annotation] = SENTINEL, **kwargs):
         """ListTemplateAnnotationsResponse
 
         :param annotations: annotations, defaults to None
         :type annotations: List[Annotation], optional
         """
-        if annotations is not None:
+        if annotations is not SENTINEL:
             self.annotations = self._define_list(annotations, Annotation)
         self._kwargs = kwargs

--- a/src/signplus/models/list_template_document_annotations_response.py
+++ b/src/signplus/models/list_template_document_annotations_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from typing import List
 from .utils.json_map import JsonMap
 from .utils.base_model import BaseModel
+from .utils.sentinel import SENTINEL
 from .annotation import Annotation
 
 
@@ -13,12 +14,12 @@ class ListTemplateDocumentAnnotationsResponse(BaseModel):
     :type annotations: List[Annotation], optional
     """
 
-    def __init__(self, annotations: List[Annotation] = None, **kwargs):
+    def __init__(self, annotations: List[Annotation] = SENTINEL, **kwargs):
         """ListTemplateDocumentAnnotationsResponse
 
         :param annotations: annotations, defaults to None
         :type annotations: List[Annotation], optional
         """
-        if annotations is not None:
+        if annotations is not SENTINEL:
             self.annotations = self._define_list(annotations, Annotation)
         self._kwargs = kwargs

--- a/src/signplus/models/list_template_documents_response.py
+++ b/src/signplus/models/list_template_documents_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from typing import List
 from .utils.json_map import JsonMap
 from .utils.base_model import BaseModel
+from .utils.sentinel import SENTINEL
 from .document import Document
 
 
@@ -13,12 +14,12 @@ class ListTemplateDocumentsResponse(BaseModel):
     :type documents: List[Document], optional
     """
 
-    def __init__(self, documents: List[Document] = None, **kwargs):
+    def __init__(self, documents: List[Document] = SENTINEL, **kwargs):
         """ListTemplateDocumentsResponse
 
         :param documents: documents, defaults to None
         :type documents: List[Document], optional
         """
-        if documents is not None:
+        if documents is not SENTINEL:
             self.documents = self._define_list(documents, Document)
         self._kwargs = kwargs

--- a/src/signplus/models/list_templates_request.py
+++ b/src/signplus/models/list_templates_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from typing import List
 from .utils.json_map import JsonMap
 from .utils.base_model import BaseModel
+from .utils.sentinel import SENTINEL
 from .template_order_field import TemplateOrderField
 
 
@@ -31,15 +32,15 @@ class ListTemplatesRequest(BaseModel):
 
     def __init__(
         self,
-        name: str = None,
-        tags: List[str] = None,
-        ids: List[str] = None,
-        first: int = None,
-        last: int = None,
-        after: str = None,
-        before: str = None,
-        order_field: TemplateOrderField = None,
-        ascending: bool = None,
+        name: str = SENTINEL,
+        tags: List[str] = SENTINEL,
+        ids: List[str] = SENTINEL,
+        first: int = SENTINEL,
+        last: int = SENTINEL,
+        after: str = SENTINEL,
+        before: str = SENTINEL,
+        order_field: TemplateOrderField = SENTINEL,
+        ascending: bool = SENTINEL,
         **kwargs,
     ):
         """ListTemplatesRequest
@@ -63,24 +64,24 @@ class ListTemplatesRequest(BaseModel):
         :param ascending: Whether to order templates in ascending order, defaults to None
         :type ascending: bool, optional
         """
-        if name is not None:
+        if name is not SENTINEL:
             self.name = name
-        if tags is not None:
+        if tags is not SENTINEL:
             self.tags = tags
-        if ids is not None:
+        if ids is not SENTINEL:
             self.ids = ids
-        if first is not None:
+        if first is not SENTINEL:
             self.first = first
-        if last is not None:
+        if last is not SENTINEL:
             self.last = last
-        if after is not None:
+        if after is not SENTINEL:
             self.after = after
-        if before is not None:
+        if before is not SENTINEL:
             self.before = before
-        if order_field is not None:
+        if order_field is not SENTINEL:
             self.order_field = self._enum_matching(
                 order_field, TemplateOrderField.list(), "order_field"
             )
-        if ascending is not None:
+        if ascending is not SENTINEL:
             self.ascending = ascending
         self._kwargs = kwargs

--- a/src/signplus/models/list_templates_response.py
+++ b/src/signplus/models/list_templates_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from typing import List
 from .utils.json_map import JsonMap
 from .utils.base_model import BaseModel
+from .utils.sentinel import SENTINEL
 from .template import Template
 
 
@@ -19,9 +20,9 @@ class ListTemplatesResponse(BaseModel):
 
     def __init__(
         self,
-        has_next_page: bool = None,
-        has_previous_page: bool = None,
-        templates: List[Template] = None,
+        has_next_page: bool = SENTINEL,
+        has_previous_page: bool = SENTINEL,
+        templates: List[Template] = SENTINEL,
         **kwargs,
     ):
         """ListTemplatesResponse
@@ -33,10 +34,10 @@ class ListTemplatesResponse(BaseModel):
         :param templates: templates, defaults to None
         :type templates: List[Template], optional
         """
-        if has_next_page is not None:
+        if has_next_page is not SENTINEL:
             self.has_next_page = has_next_page
-        if has_previous_page is not None:
+        if has_previous_page is not SENTINEL:
             self.has_previous_page = has_previous_page
-        if templates is not None:
+        if templates is not SENTINEL:
             self.templates = self._define_list(templates, Template)
         self._kwargs = kwargs

--- a/src/signplus/models/list_webhooks_request.py
+++ b/src/signplus/models/list_webhooks_request.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from .utils.json_map import JsonMap
 from .utils.base_model import BaseModel
+from .utils.sentinel import SENTINEL
 from .webhook_event import WebhookEvent
 
 
@@ -14,7 +15,9 @@ class ListWebhooksRequest(BaseModel):
     :type event: WebhookEvent, optional
     """
 
-    def __init__(self, webhook_id: str = None, event: WebhookEvent = None, **kwargs):
+    def __init__(
+        self, webhook_id: str = SENTINEL, event: WebhookEvent = SENTINEL, **kwargs
+    ):
         """ListWebhooksRequest
 
         :param webhook_id: ID of the webhook, defaults to None
@@ -22,8 +25,8 @@ class ListWebhooksRequest(BaseModel):
         :param event: Event of the webhook, defaults to None
         :type event: WebhookEvent, optional
         """
-        if webhook_id is not None:
+        if webhook_id is not SENTINEL:
             self.webhook_id = webhook_id
-        if event is not None:
+        if event is not SENTINEL:
             self.event = self._enum_matching(event, WebhookEvent.list(), "event")
         self._kwargs = kwargs

--- a/src/signplus/models/list_webhooks_response.py
+++ b/src/signplus/models/list_webhooks_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from typing import List
 from .utils.json_map import JsonMap
 from .utils.base_model import BaseModel
+from .utils.sentinel import SENTINEL
 from .webhook import Webhook
 
 
@@ -13,12 +14,12 @@ class ListWebhooksResponse(BaseModel):
     :type webhooks: List[Webhook], optional
     """
 
-    def __init__(self, webhooks: List[Webhook] = None, **kwargs):
+    def __init__(self, webhooks: List[Webhook] = SENTINEL, **kwargs):
         """ListWebhooksResponse
 
         :param webhooks: webhooks, defaults to None
         :type webhooks: List[Webhook], optional
         """
-        if webhooks is not None:
+        if webhooks is not SENTINEL:
             self.webhooks = self._define_list(webhooks, Webhook)
         self._kwargs = kwargs

--- a/src/signplus/models/page.py
+++ b/src/signplus/models/page.py
@@ -1,5 +1,6 @@
 from .utils.json_map import JsonMap
 from .utils.base_model import BaseModel
+from .utils.sentinel import SENTINEL
 
 
 @JsonMap({})
@@ -12,7 +13,7 @@ class Page(BaseModel):
     :type height: int, optional
     """
 
-    def __init__(self, width: int = None, height: int = None, **kwargs):
+    def __init__(self, width: int = SENTINEL, height: int = SENTINEL, **kwargs):
         """Page
 
         :param width: Width of the page in pixels, defaults to None
@@ -20,8 +21,8 @@ class Page(BaseModel):
         :param height: Height of the page in pixels, defaults to None
         :type height: int, optional
         """
-        if width is not None:
+        if width is not SENTINEL:
             self.width = width
-        if height is not None:
+        if height is not SENTINEL:
             self.height = height
         self._kwargs = kwargs

--- a/src/signplus/models/recipient.py
+++ b/src/signplus/models/recipient.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from .utils.json_map import JsonMap
 from .utils.base_model import BaseModel
+from .utils.sentinel import SENTINEL
 from .recipient_role import RecipientRole
 from .recipient_verification import RecipientVerification
 
@@ -28,9 +29,9 @@ class Recipient(BaseModel):
         name: str,
         email: str,
         role: RecipientRole,
-        id_: str = None,
-        uid: str = None,
-        verification: RecipientVerification = None,
+        id_: str = SENTINEL,
+        uid: str = SENTINEL,
+        verification: RecipientVerification = SENTINEL,
         **kwargs,
     ):
         """Recipient
@@ -48,13 +49,13 @@ class Recipient(BaseModel):
         :param verification: verification, defaults to None
         :type verification: RecipientVerification, optional
         """
-        if id_ is not None:
+        if id_ is not SENTINEL:
             self.id_ = id_
-        if uid is not None:
+        if uid is not SENTINEL:
             self.uid = uid
         self.name = name
         self.email = email
         self.role = self._enum_matching(role, RecipientRole.list(), "role")
-        if verification is not None:
+        if verification is not SENTINEL:
             self.verification = self._define_object(verification, RecipientVerification)
         self._kwargs = kwargs

--- a/src/signplus/models/recipient_verification.py
+++ b/src/signplus/models/recipient_verification.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from .utils.json_map import JsonMap
 from .utils.base_model import BaseModel
+from .utils.sentinel import SENTINEL
 from .recipient_verification_type import RecipientVerificationType
 
 
@@ -8,26 +9,29 @@ from .recipient_verification_type import RecipientVerificationType
 class RecipientVerification(BaseModel):
     """RecipientVerification
 
-    :param type_: Type of signature verification (SMS sends a code via SMS, PASSCODE requires a code to be entered), defaults to None
+    :param type_: Type of verification the recipient must complete before accessing the envelope. - `PASSCODE`: requires a code to be entered.   - `SMS`: sends a code via SMS.   - `ID_VERIFICATION`: prompts the recipient to complete an automated ID and selfie check., defaults to None
     :type type_: RecipientVerificationType, optional
-    :param value: value, defaults to None
+    :param value: Required for `PASSCODE` and `SMS` verification. - `PASSCODE`: code required by the recipient to sign the document. - `SMS`: recipient's phone number. - `ID_VERIFICATION`: leave empty., defaults to None
     :type value: str, optional
     """
 
     def __init__(
-        self, type_: RecipientVerificationType = None, value: str = None, **kwargs
+        self,
+        type_: RecipientVerificationType = SENTINEL,
+        value: str = SENTINEL,
+        **kwargs,
     ):
         """RecipientVerification
 
-        :param type_: Type of signature verification (SMS sends a code via SMS, PASSCODE requires a code to be entered), defaults to None
+        :param type_: Type of verification the recipient must complete before accessing the envelope. - `PASSCODE`: requires a code to be entered.   - `SMS`: sends a code via SMS.   - `ID_VERIFICATION`: prompts the recipient to complete an automated ID and selfie check., defaults to None
         :type type_: RecipientVerificationType, optional
-        :param value: value, defaults to None
+        :param value: Required for `PASSCODE` and `SMS` verification. - `PASSCODE`: code required by the recipient to sign the document. - `SMS`: recipient's phone number. - `ID_VERIFICATION`: leave empty., defaults to None
         :type value: str, optional
         """
-        if type_ is not None:
+        if type_ is not SENTINEL:
             self.type_ = self._enum_matching(
                 type_, RecipientVerificationType.list(), "type_"
             )
-        if value is not None:
+        if value is not SENTINEL:
             self.value = value
         self._kwargs = kwargs

--- a/src/signplus/models/recipient_verification_type.py
+++ b/src/signplus/models/recipient_verification_type.py
@@ -8,10 +8,13 @@ class RecipientVerificationType(Enum):
     :vartype SMS: str
     :cvar PASSCODE: "PASSCODE"
     :vartype PASSCODE: str
+    :cvar IDVERIFICATION: "ID_VERIFICATION"
+    :vartype IDVERIFICATION: str
     """
 
     SMS = "SMS"
     PASSCODE = "PASSCODE"
+    IDVERIFICATION = "ID_VERIFICATION"
 
     def list():
         """Lists all category values.

--- a/src/signplus/models/rename_envelope_request.py
+++ b/src/signplus/models/rename_envelope_request.py
@@ -1,5 +1,6 @@
 from .utils.json_map import JsonMap
 from .utils.base_model import BaseModel
+from .utils.sentinel import SENTINEL
 
 
 @JsonMap({})
@@ -10,12 +11,12 @@ class RenameEnvelopeRequest(BaseModel):
     :type name: str, optional
     """
 
-    def __init__(self, name: str = None, **kwargs):
+    def __init__(self, name: str = SENTINEL, **kwargs):
         """RenameEnvelopeRequest
 
         :param name: Name of the envelope, defaults to None
         :type name: str, optional
         """
-        if name is not None:
+        if name is not SENTINEL:
             self.name = name
         self._kwargs = kwargs

--- a/src/signplus/models/set_envelope_legality_level_request.py
+++ b/src/signplus/models/set_envelope_legality_level_request.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from .utils.json_map import JsonMap
 from .utils.base_model import BaseModel
+from .utils.sentinel import SENTINEL
 from .envelope_legality_level import EnvelopeLegalityLevel
 
 
@@ -12,13 +13,13 @@ class SetEnvelopeLegalityLevelRequest(BaseModel):
     :type legality_level: EnvelopeLegalityLevel, optional
     """
 
-    def __init__(self, legality_level: EnvelopeLegalityLevel = None, **kwargs):
+    def __init__(self, legality_level: EnvelopeLegalityLevel = SENTINEL, **kwargs):
         """SetEnvelopeLegalityLevelRequest
 
         :param legality_level: Legal level of the envelope (SES is Simple Electronic Signature, QES_EIDAS is Qualified Electronic Signature, QES_ZERTES is Qualified Electronic Signature with Zertes), defaults to None
         :type legality_level: EnvelopeLegalityLevel, optional
         """
-        if legality_level is not None:
+        if legality_level is not SENTINEL:
             self.legality_level = self._enum_matching(
                 legality_level, EnvelopeLegalityLevel.list(), "legality_level"
             )

--- a/src/signplus/models/signing_step.py
+++ b/src/signplus/models/signing_step.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from typing import List
 from .utils.json_map import JsonMap
 from .utils.base_model import BaseModel
+from .utils.sentinel import SENTINEL
 from .recipient import Recipient
 
 
@@ -13,12 +14,12 @@ class SigningStep(BaseModel):
     :type recipients: List[Recipient], optional
     """
 
-    def __init__(self, recipients: List[Recipient] = None, **kwargs):
+    def __init__(self, recipients: List[Recipient] = SENTINEL, **kwargs):
         """SigningStep
 
         :param recipients: List of recipients, defaults to None
         :type recipients: List[Recipient], optional
         """
-        if recipients is not None:
+        if recipients is not SENTINEL:
             self.recipients = self._define_list(recipients, Recipient)
         self._kwargs = kwargs

--- a/src/signplus/models/template.py
+++ b/src/signplus/models/template.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from typing import List
 from .utils.json_map import JsonMap
 from .utils.base_model import BaseModel
+from .utils.sentinel import SENTINEL
 from .envelope_legality_level import EnvelopeLegalityLevel
 from .template_signing_step import TemplateSigningStep
 from .document import Document
@@ -42,19 +43,19 @@ class Template(BaseModel):
 
     def __init__(
         self,
-        id_: str = None,
-        name: str = None,
-        comment: str = None,
-        pages: int = None,
-        legality_level: EnvelopeLegalityLevel = None,
-        created_at: int = None,
-        updated_at: int = None,
-        expiration_delay: int = None,
-        num_recipients: int = None,
-        signing_steps: List[TemplateSigningStep] = None,
-        documents: List[Document] = None,
-        notification: EnvelopeNotification = None,
-        dynamic_fields: List[str] = None,
+        id_: str = SENTINEL,
+        name: str = SENTINEL,
+        comment: str = SENTINEL,
+        pages: int = SENTINEL,
+        legality_level: EnvelopeLegalityLevel = SENTINEL,
+        created_at: int = SENTINEL,
+        updated_at: int = SENTINEL,
+        expiration_delay: int = SENTINEL,
+        num_recipients: int = SENTINEL,
+        signing_steps: List[TemplateSigningStep] = SENTINEL,
+        documents: List[Document] = SENTINEL,
+        notification: EnvelopeNotification = SENTINEL,
+        dynamic_fields: List[str] = SENTINEL,
         **kwargs,
     ):
         """Template
@@ -86,32 +87,32 @@ class Template(BaseModel):
         :param dynamic_fields: List of dynamic fields, defaults to None
         :type dynamic_fields: List[str], optional
         """
-        if id_ is not None:
+        if id_ is not SENTINEL:
             self.id_ = id_
-        if name is not None:
+        if name is not SENTINEL:
             self.name = name
-        if comment is not None:
+        if comment is not SENTINEL:
             self.comment = comment
-        if pages is not None:
+        if pages is not SENTINEL:
             self.pages = pages
-        if legality_level is not None:
+        if legality_level is not SENTINEL:
             self.legality_level = self._enum_matching(
                 legality_level, EnvelopeLegalityLevel.list(), "legality_level"
             )
-        if created_at is not None:
+        if created_at is not SENTINEL:
             self.created_at = created_at
-        if updated_at is not None:
+        if updated_at is not SENTINEL:
             self.updated_at = updated_at
-        if expiration_delay is not None:
+        if expiration_delay is not SENTINEL:
             self.expiration_delay = expiration_delay
-        if num_recipients is not None:
+        if num_recipients is not SENTINEL:
             self.num_recipients = num_recipients
-        if signing_steps is not None:
+        if signing_steps is not SENTINEL:
             self.signing_steps = self._define_list(signing_steps, TemplateSigningStep)
-        if documents is not None:
+        if documents is not SENTINEL:
             self.documents = self._define_list(documents, Document)
-        if notification is not None:
+        if notification is not SENTINEL:
             self.notification = self._define_object(notification, EnvelopeNotification)
-        if dynamic_fields is not None:
+        if dynamic_fields is not SENTINEL:
             self.dynamic_fields = dynamic_fields
         self._kwargs = kwargs

--- a/src/signplus/models/template_recipient.py
+++ b/src/signplus/models/template_recipient.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from .utils.json_map import JsonMap
 from .utils.base_model import BaseModel
+from .utils.sentinel import SENTINEL
 from .template_recipient_role import TemplateRecipientRole
 
 
@@ -22,11 +23,11 @@ class TemplateRecipient(BaseModel):
 
     def __init__(
         self,
-        id_: str = None,
-        uid: str = None,
-        name: str = None,
-        email: str = None,
-        role: TemplateRecipientRole = None,
+        id_: str = SENTINEL,
+        uid: str = SENTINEL,
+        name: str = SENTINEL,
+        email: str = SENTINEL,
+        role: TemplateRecipientRole = SENTINEL,
         **kwargs,
     ):
         """TemplateRecipient
@@ -42,14 +43,14 @@ class TemplateRecipient(BaseModel):
         :param role: Role of the recipient (SIGNER signs the document, RECEIVES_COPY receives a copy of the document, IN_PERSON_SIGNER signs the document in person, SENDER sends the document), defaults to None
         :type role: TemplateRecipientRole, optional
         """
-        if id_ is not None:
+        if id_ is not SENTINEL:
             self.id_ = id_
-        if uid is not None:
+        if uid is not SENTINEL:
             self.uid = uid
-        if name is not None:
+        if name is not SENTINEL:
             self.name = name
-        if email is not None:
+        if email is not SENTINEL:
             self.email = email
-        if role is not None:
+        if role is not SENTINEL:
             self.role = self._enum_matching(role, TemplateRecipientRole.list(), "role")
         self._kwargs = kwargs

--- a/src/signplus/models/template_recipient_role.py
+++ b/src/signplus/models/template_recipient_role.py
@@ -10,11 +10,14 @@ class TemplateRecipientRole(Enum):
     :vartype RECEIVESCOPY: str
     :cvar INPERSONSIGNER: "IN_PERSON_SIGNER"
     :vartype INPERSONSIGNER: str
+    :cvar SENDER: "SENDER"
+    :vartype SENDER: str
     """
 
     SIGNER = "SIGNER"
     RECEIVESCOPY = "RECEIVES_COPY"
     INPERSONSIGNER = "IN_PERSON_SIGNER"
+    SENDER = "SENDER"
 
     def list():
         """Lists all category values.

--- a/src/signplus/models/template_signing_step.py
+++ b/src/signplus/models/template_signing_step.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from typing import List
 from .utils.json_map import JsonMap
 from .utils.base_model import BaseModel
+from .utils.sentinel import SENTINEL
 from .template_recipient import TemplateRecipient
 
 
@@ -13,12 +14,12 @@ class TemplateSigningStep(BaseModel):
     :type recipients: List[TemplateRecipient], optional
     """
 
-    def __init__(self, recipients: List[TemplateRecipient] = None, **kwargs):
+    def __init__(self, recipients: List[TemplateRecipient] = SENTINEL, **kwargs):
         """TemplateSigningStep
 
         :param recipients: List of recipients, defaults to None
         :type recipients: List[TemplateRecipient], optional
         """
-        if recipients is not None:
+        if recipients is not SENTINEL:
             self.recipients = self._define_list(recipients, TemplateRecipient)
         self._kwargs = kwargs

--- a/src/signplus/models/utils/base_model.py
+++ b/src/signplus/models/utils/base_model.py
@@ -3,6 +3,7 @@ import operator
 from typing import List, Union, Type, Any, TypeVar, Optional
 from enum import Enum
 from .one_of_base_model import OneOfBaseModel
+from .sentinel import SENTINEL
 
 T = TypeVar("T")
 
@@ -25,7 +26,7 @@ class BaseModel:
         :return: The input data if it is an instance of input_class, otherwise an instance of input_class.
         :rtype: object
         """
-        if input_data is None:
+        if input_data is None or input_data is SENTINEL:
             return None
         elif isinstance(input_data, input_class):
             return input_data
@@ -43,7 +44,7 @@ class BaseModel:
         :rtype: list
         """
 
-        if input_data is None:
+        if input_data is None or input_data is SENTINEL:
             return None
 
         result: List[T] = []
@@ -99,7 +100,7 @@ class BaseModel:
         """
         if value is None and not nullable:
             raise ValueError(f"{variable_name} cannot be null.")
-        if value is None:
+        if value is None or value is SENTINEL:
             return None
 
         if pattern:
@@ -152,7 +153,7 @@ class BaseModel:
         if value is None and not nullable:
             raise ValueError(f"{variable_name} cannot be null.")
 
-        if value is None:
+        if value is None or value is SENTINEL:
             return None
 
         if ge is not None:

--- a/src/signplus/models/utils/cast_models.py
+++ b/src/signplus/models/utils/cast_models.py
@@ -38,7 +38,7 @@ def cast_models(func):
         # Instanciate oneOf models
         if _is_one_of_model(input_type):
             class_list = {
-                arg.__name__: arg for arg in get_args(input_type) if arg.__name__
+                getattr(arg, "__name__", str(arg)): arg for arg in get_args(input_type)
             }
             OneOfBaseModel.class_list = class_list
             return OneOfBaseModel.return_one_of(data)

--- a/src/signplus/models/utils/json_map.py
+++ b/src/signplus/models/utils/json_map.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from .sentinel import was_value_set
 
 
 class JsonMap:
@@ -45,7 +46,7 @@ class JsonMap:
             result_dict = {}
 
             for key, value in attribute_dict.items():
-                if key == "_kwargs":
+                if key == "_kwargs" or not was_value_set(value):
                     continue
                 if isinstance(value, list):
                     value = [v._map() if hasattr(v, "_map") else v for v in value]
@@ -70,6 +71,7 @@ class JsonMap:
             """
             reversed_map = {v: k for k, v in cls.__json_mapping.items()}
             mapped_attributes = {}
+
             for key, value in mapped_data.items():
                 mapped_key = reversed_map.get(key, key)
                 mapped_attributes[mapped_key] = value

--- a/src/signplus/models/utils/sentinel.py
+++ b/src/signplus/models/utils/sentinel.py
@@ -1,0 +1,17 @@
+"""
+Defines the SENTINEL object to be used to represent a nullable value.
+"""
+
+from typing import Any
+
+SENTINEL = object()
+
+
+def was_value_set(value: Any) -> bool:
+    """Returns True if the value was set, False otherwise.
+
+    :param value: The value to check.
+    :type value: Any
+    :return: True if the value was set, False otherwise.
+    """
+    return value is not SENTINEL

--- a/src/signplus/models/webhook.py
+++ b/src/signplus/models/webhook.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from .utils.json_map import JsonMap
 from .utils.base_model import BaseModel
+from .utils.sentinel import SENTINEL
 from .webhook_event import WebhookEvent
 
 
@@ -17,7 +18,11 @@ class Webhook(BaseModel):
     """
 
     def __init__(
-        self, id_: str = None, event: WebhookEvent = None, target: str = None, **kwargs
+        self,
+        id_: str = SENTINEL,
+        event: WebhookEvent = SENTINEL,
+        target: str = SENTINEL,
+        **kwargs,
     ):
         """Webhook
 
@@ -28,10 +33,10 @@ class Webhook(BaseModel):
         :param target: Target URL of the webhook, defaults to None
         :type target: str, optional
         """
-        if id_ is not None:
+        if id_ is not SENTINEL:
             self.id_ = id_
-        if event is not None:
+        if event is not SENTINEL:
             self.event = self._enum_matching(event, WebhookEvent.list(), "event")
-        if target is not None:
+        if target is not SENTINEL:
             self.target = target
         self._kwargs = kwargs

--- a/src/signplus/net/environment/environment.py
+++ b/src/signplus/net/environment/environment.py
@@ -3,9 +3,27 @@ An enum class containing all the possible environments for the SDK
 """
 
 from enum import Enum
+from urllib.parse import urlparse
 
 
 class Environment(Enum):
     """The environments available for the SDK"""
 
     DEFAULT = "https://restapi.sign.plus/v2"
+
+    def __new__(cls, url):
+        parsed_url = urlparse(url)
+        if not all([parsed_url.scheme, parsed_url.netloc]):
+            raise ValueError(
+                f"Environment url [{url}] is not valid. Please use the following format https://api.example.com"
+            )
+
+        obj = object.__new__(cls)
+        obj._value_ = url
+        obj._url = url
+        return obj
+
+    @property
+    def url(self):
+        """Get the base URL for this environment"""
+        return self._url

--- a/src/signplus/net/request_chain/handlers/base_handler.py
+++ b/src/signplus/net/request_chain/handlers/base_handler.py
@@ -1,7 +1,6 @@
 from typing import Generator, Optional, Tuple
 from ...transport.request import Request
 from ...transport.response import Response
-from ...transport.request_error import RequestError
 
 
 class BaseHandler:
@@ -19,27 +18,27 @@ class BaseHandler:
 
     def handle(
         self, request: Request
-    ) -> Tuple[Optional[Response], Optional[RequestError]]:
+    ) -> Tuple[Optional[Response], Optional[Exception]]:
         """
         Process the given request and return a response or an error.
         This method must be implemented by all subclasses.
 
         :param Request request: The request to handle.
         :return: The response and any error that occurred.
-        :rtype: Tuple[Optional[Response], Optional[RequestError]]
+        :rtype: Tuple[Optional[Response], Optional[Exception]]
         """
         raise NotImplementedError()
 
     def stream(
         self, request: Request
-    ) -> Generator[Tuple[Optional[Response], Optional[RequestError]], None, None]:
+    ) -> Generator[Tuple[Optional[Response], Optional[Exception]], None, None]:
         """
         Stream the given request and return a response or an error.
         This method must be implemented by all subclasses.
 
         :param Request request: The request to stream.
         :return: The response and any error that occurred.
-        :rtype: Generator[Tuple[Optional[Response], Optional[RequestError]], None, None]
+        :rtype: Generator[Tuple[Optional[Response], Optional[Exception]], None, None]
         """
         raise NotImplementedError()
 

--- a/src/signplus/net/request_chain/handlers/http_handler.py
+++ b/src/signplus/net/request_chain/handlers/http_handler.py
@@ -5,7 +5,7 @@ from typing import Generator, Optional, Tuple
 from .base_handler import BaseHandler
 from ...transport.request import Request
 from ...transport.response import Response
-from ...transport.request_error import RequestError
+from ...transport.api_error import ApiError
 
 
 class HttpHandler(BaseHandler):
@@ -25,13 +25,13 @@ class HttpHandler(BaseHandler):
 
     def handle(
         self, request: Request
-    ) -> Tuple[Optional[Response], Optional[RequestError]]:
+    ) -> Tuple[Optional[Response], Optional[Exception]]:
         """
         Send the request to the specified URL and return the response.
 
         :param Request request: The request to send.
         :return: The response and any error that occurred.
-        :rtype: Tuple[Optional[Response], Optional[RequestError]]
+        :rtype: Tuple[Optional[Response], Optional[Exception]]
         """
         try:
             request_args = self._get_request_data(request)
@@ -46,7 +46,21 @@ class HttpHandler(BaseHandler):
             response = Response(result)
 
             if response.status >= 400:
-                return None, RequestError(
+                if response.status in request.errors and isinstance(
+                    response.body, dict
+                ):
+                    error_model_class = request.errors[response.status]
+                    error = error_model_class(**response.body)
+                    if "message" not in response.body:
+                        error.message = (
+                            f"{response.status} error in request to: {request.url}"
+                        )
+                    error.status = response.status
+                    error.response = response
+
+                    return None, error
+
+                return None, ApiError(
                     message=f"{response.status} error in request to: {request.url}",
                     status=response.status,
                     response=response,
@@ -54,11 +68,11 @@ class HttpHandler(BaseHandler):
 
             return response, None
         except Timeout:
-            return None, RequestError("Request timed out")
+            return None, ApiError("Request timed out", status=408)
 
     def stream(
         self, request: Request
-    ) -> Generator[Tuple[Optional[Response], Optional[RequestError]], None, None]:
+    ) -> Generator[Tuple[Optional[Response], Optional[Exception]], None, None]:
         try:
             request_args = self._get_request_data(request)
 
@@ -75,7 +89,7 @@ class HttpHandler(BaseHandler):
                 response = Response(result)
                 yield (
                     None,
-                    RequestError(
+                    ApiError(
                         message=f"{response.status} error in request to: {request.url}",
                         status=response.status,
                         response=response,
@@ -88,7 +102,7 @@ class HttpHandler(BaseHandler):
                         yield response, None
 
         except Timeout:
-            yield None, RequestError("Request timed out")
+            yield None, ApiError("Request timed out", status=408)
 
     def _get_request_data(self, request: Request) -> dict:
         """
@@ -113,7 +127,7 @@ class HttpHandler(BaseHandler):
             files, form_data = {}, {}
             for key, value in data.items():
                 if isinstance(value, bytes):
-                    files[key] = value
+                    files[key] = (key, value, "application/octet-stream")
                 else:
                     form_data[key] = value
             return {"files": files, "data": form_data}

--- a/src/signplus/net/request_chain/handlers/retry_handler.py
+++ b/src/signplus/net/request_chain/handlers/retry_handler.py
@@ -5,6 +5,7 @@ from time import sleep
 from .base_handler import BaseHandler
 from ...transport.request import Request
 from ...transport.response import Response
+from ...transport.api_error import ApiError
 from ...transport.request_error import RequestError
 
 
@@ -86,12 +87,12 @@ class RetryHandler(BaseHandler):
         delay = self._delay_in_milliseconds * (2**try_count) * jitter / 1000
         sleep(delay)
 
-    def _should_retry(self, error: Optional[RequestError]) -> bool:
+    def _should_retry(self, error: Optional[ApiError]) -> bool:
         """
         Determine whether the request should be retried.
 
         :param Optional[Response] response: The response from the previous handler.
-        :param Optional[RequestError] error: The error from the previous handler.
+        :param Optional[ApiError] error: The error from the previous handler.
         :return: True if the request should be retried, False otherwise.
         :rtype: bool
         """

--- a/src/signplus/net/transport/api_error.py
+++ b/src/signplus/net/transport/api_error.py
@@ -1,0 +1,28 @@
+from ...models.utils.base_model import BaseModel
+from .response import Response
+from typing import Optional
+
+
+class ApiError(BaseModel, Exception):
+    """
+    Class representing an API Error.
+
+    :ivar Optional[int] status: The status code of the HTTP error.
+    :ivar Optional[Response] response: The response associated with the error.
+    """
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        status: Optional[int] = None,
+        response: Optional[Response] = None,
+    ):
+        """
+        Initialize a new instance of API Error.
+
+        :param Optional[int] status: The status code of the HTTP error.
+        :param Optional[Response] response: The response associated with the error.
+        """
+        self.message = message
+        self.status = status
+        self.response = response

--- a/src/signplus/net/transport/request.py
+++ b/src/signplus/net/transport/request.py
@@ -25,6 +25,8 @@ class Request:
     :ivar str method: The HTTP method for the request.
     :ivar dict headers: Dictionary of headers to include in the request.
     :ivar Any body: Request body.
+    :ivar Set[str] scopes: List of scopes to include in the request.
+    :ivar dict errors: Dictionary of HTTP status codes to error models.
     """
 
     def __init__(self):
@@ -33,6 +35,7 @@ class Request:
         self.headers = None
         self.body = None
         self.scopes = None
+        self.errors = None
 
     def set_url(self, url: str) -> "Request":
         """
@@ -89,6 +92,17 @@ class Request:
         :rtype: Request
         """
         self.scopes = scopes
+        return self
+
+    def set_errors(self, errors: dict) -> "Request":
+        """
+        Set the errors for the request.
+
+        :param dict errors: Dictionary of HTTP status codes to error models.
+        :return: The updated Request object.
+        :rtype: Request
+        """
+        self.errors = errors
         return self
 
     def __str__(self) -> str:

--- a/src/signplus/net/transport/request_error.py
+++ b/src/signplus/net/transport/request_error.py
@@ -1,40 +1,23 @@
-from .response import Response
 from typing import Optional
 
 
-class RequestError(IOError):
+class RequestError(Exception):
     """
     Class representing a Request Error.
-
-    :ivar bool is_http_error: Indicates if the error is an HTTP error.
-    :ivar int status: The status code of the HTTP error.
-    :ivar Optional[Response] response: The response associated with the error.
     """
 
     def __init__(
         self,
         message: str,
-        status: Optional[int] = None,
-        response: Optional[Response] = None,
         stack: Optional["RequestError"] = None,
     ):
         """
         Initialize a new instance of RequestError.
 
         :param str message: The error message.
-        :param Optional[int] status: The status code of the HTTP error.
-        :param Optional[Response] response: The response associated with the error.
         """
         super().__init__(message)
-        self.response = response
         self.stack = stack
-
-        if status is not None:
-            self.status = status
-            self.is_http_error = True
-        else:
-            self.status = -1
-            self.is_http_error = False
 
     def __str__(self):
         """
@@ -46,8 +29,6 @@ class RequestError(IOError):
         error_stack = []
         current_error = self
         while current_error is not None:
-            error_stack.append(
-                f"Error: {super().__str__()}, Status Code: {current_error.status}"
-            )
+            error_stack.append(f"Error: {super().__str__()}")
             current_error = current_error.stack
         return "\n".join(error_stack)

--- a/src/signplus/net/transport/serializer.py
+++ b/src/signplus/net/transport/serializer.py
@@ -1,9 +1,11 @@
 from typing import Any, List
 from urllib.parse import quote
 
-from ...net.headers.base_header import BaseHeader
 from .request import Request
 from .utils import extract_original_data
+from ...models.utils.sentinel import was_value_set
+from ...net.headers.base_header import BaseHeader
+from ...net.transport.api_error import ApiError
 
 
 class Serializer:
@@ -15,6 +17,7 @@ class Serializer:
     :ivar list[str] cookies: A list containing cookie strings for the request.
     :ivar dict[str, str] path: A dictionary containing path parameters for the request.
     :ivar list[str] query: A list containing query parameters for the request.
+    :ivar dict[int, ApiError] errors: A dictionary of HTTP status codes to error models.
     """
 
     def __init__(self, url: str, default_headers: List[BaseHeader] = []):
@@ -29,6 +32,7 @@ class Serializer:
         self.cookies: list[str] = []
         self.path: dict[str, str] = {}
         self.query: list[str] = []
+        self.errors: dict[int, ApiError] = {}
 
         for header in default_headers:
             for key, value in header.get_headers().items():
@@ -47,6 +51,9 @@ class Serializer:
         :rtype: Serializer
         """
         if not nullable and data is None:
+            return self
+
+        if not was_value_set(data):
             return self
 
         data = extract_original_data(data)
@@ -69,6 +76,9 @@ class Serializer:
         :rtype: Serializer
         """
         if not nullable and data is None:
+            return self
+
+        if not was_value_set(data):
             return self
 
         data = extract_original_data(data)
@@ -97,6 +107,9 @@ class Serializer:
         :rtype: Serializer
         """
         if not nullable and data is None:
+            return self
+
+        if not was_value_set(data):
             return self
 
         data = extract_original_data(data)
@@ -146,6 +159,9 @@ class Serializer:
         if not nullable and data is None:
             return self
 
+        if not was_value_set(data):
+            return self
+
         data = extract_original_data(data)
 
         if style == "form":
@@ -171,6 +187,21 @@ class Serializer:
         self.query.append(query_param)
         return self
 
+    def add_error(self, status: int, error: ApiError) -> "Serializer":
+        """
+        Adds an error to the request.
+
+        :param int status: The HTTP status code associated with the error.
+        :param ApiError error: The ApiError class representing the error.
+        :return: The Serializer instance for method chaining.
+        :rtype: Serializer
+        """
+        if not was_value_set(error):
+            return self
+
+        self.errors[status] = error
+        return self
+
     def serialize(self) -> Request:
         """
         Serializes the components and returns a Request object.
@@ -183,7 +214,12 @@ class Serializer:
         if len(self.cookies) > 0:
             self.headers["Cookie"] = ";".join(self.cookies)
 
-        return Request().set_url(final_url).set_headers(self.headers)
+        return (
+            Request()
+            .set_url(final_url)
+            .set_headers(self.headers)
+            .set_errors(self.errors)
+        )
 
     def _define_url(self) -> str:
         """

--- a/src/signplus/sdk.py
+++ b/src/signplus/sdk.py
@@ -7,7 +7,7 @@ class Signplus:
     def __init__(
         self,
         access_token: str = None,
-        base_url: Union[Environment, str] = Environment.DEFAULT,
+        base_url: Union[Environment, str, None] = None,
         timeout: int = 60000,
     ):
         """

--- a/src/signplus/sdk_async.py
+++ b/src/signplus/sdk_async.py
@@ -1,0 +1,20 @@
+from typing import Union
+from .net.environment import Environment
+from .sdk import Signplus
+from .services.async_.signplus import SignplusServiceAsync
+
+
+class SignplusAsync(Signplus):
+    """
+    SignplusAsync is the asynchronous version of the Signplus SDK Client.
+    """
+
+    def __init__(
+        self,
+        access_token: str = None,
+        base_url: Union[Environment, str, None] = None,
+        timeout: int = 60000,
+    ):
+        super().__init__(access_token=access_token, base_url=base_url, timeout=timeout)
+
+        self.signplus = SignplusServiceAsync(base_url=self._base_url)

--- a/src/signplus/services/async_/signplus.py
+++ b/src/signplus/services/async_/signplus.py
@@ -1,0 +1,244 @@
+from typing import Awaitable, List
+from .utils.to_async import to_async
+from ..signplus import SignplusService
+from ...models.utils.sentinel import SENTINEL
+from ...models import (
+    Envelope,
+    CreateEnvelopeRequest,
+    CreateEnvelopeFromTemplateRequest,
+    ListEnvelopesResponse,
+    ListEnvelopesRequest,
+    Document,
+    ListEnvelopeDocumentsResponse,
+    AddEnvelopeDocumentRequest,
+    SetEnvelopeDynamicFieldsRequest,
+    AddEnvelopeSigningStepsRequest,
+    RenameEnvelopeRequest,
+    SetEnvelopeCommentRequest,
+    EnvelopeNotification,
+    SetEnvelopeExpirationRequest,
+    SetEnvelopeLegalityLevelRequest,
+    Annotation,
+    ListEnvelopeDocumentAnnotationsResponse,
+    AddAnnotationRequest,
+    Template,
+    CreateTemplateRequest,
+    ListTemplatesResponse,
+    ListTemplatesRequest,
+    AddTemplateDocumentRequest,
+    ListTemplateDocumentsResponse,
+    AddTemplateSigningStepsRequest,
+    RenameTemplateRequest,
+    SetTemplateCommentRequest,
+    ListTemplateAnnotationsResponse,
+    ListTemplateDocumentAnnotationsResponse,
+    Webhook,
+    CreateWebhookRequest,
+    ListWebhooksResponse,
+    ListWebhooksRequest,
+)
+
+
+class SignplusServiceAsync(SignplusService):
+    """
+    Async Wrapper for SignplusServiceAsync
+    """
+
+    def create_envelope(
+        self, request_body: CreateEnvelopeRequest
+    ) -> Awaitable[Envelope]:
+        return to_async(super().create_envelope)(request_body)
+
+    def create_envelope_from_template(
+        self, request_body: CreateEnvelopeFromTemplateRequest, template_id: str
+    ) -> Awaitable[Envelope]:
+        return to_async(super().create_envelope_from_template)(
+            request_body, template_id
+        )
+
+    def list_envelopes(
+        self, request_body: ListEnvelopesRequest = None
+    ) -> Awaitable[ListEnvelopesResponse]:
+        return to_async(super().list_envelopes)(request_body)
+
+    def get_envelope(self, envelope_id: str) -> Awaitable[Envelope]:
+        return to_async(super().get_envelope)(envelope_id)
+
+    def delete_envelope(self, envelope_id: str) -> Awaitable[None]:
+        return to_async(super().delete_envelope)(envelope_id)
+
+    def download_envelope_signed_documents(
+        self, envelope_id: str, certificate_of_completion: bool = SENTINEL
+    ) -> Awaitable[any]:
+        return to_async(super().download_envelope_signed_documents)(
+            envelope_id, certificate_of_completion
+        )
+
+    def download_envelope_certificate(self, envelope_id: str) -> Awaitable[any]:
+        return to_async(super().download_envelope_certificate)(envelope_id)
+
+    def get_envelope_document(
+        self, envelope_id: str, document_id: str
+    ) -> Awaitable[Document]:
+        return to_async(super().get_envelope_document)(envelope_id, document_id)
+
+    def get_envelope_documents(
+        self, envelope_id: str
+    ) -> Awaitable[ListEnvelopeDocumentsResponse]:
+        return to_async(super().get_envelope_documents)(envelope_id)
+
+    def add_envelope_document(
+        self, request_body: AddEnvelopeDocumentRequest, envelope_id: str
+    ) -> Awaitable[Document]:
+        return to_async(super().add_envelope_document)(request_body, envelope_id)
+
+    def set_envelope_dynamic_fields(
+        self, request_body: SetEnvelopeDynamicFieldsRequest, envelope_id: str
+    ) -> Awaitable[Envelope]:
+        return to_async(super().set_envelope_dynamic_fields)(request_body, envelope_id)
+
+    def add_envelope_signing_steps(
+        self, request_body: AddEnvelopeSigningStepsRequest, envelope_id: str
+    ) -> Awaitable[Envelope]:
+        return to_async(super().add_envelope_signing_steps)(request_body, envelope_id)
+
+    def send_envelope(self, envelope_id: str) -> Awaitable[Envelope]:
+        return to_async(super().send_envelope)(envelope_id)
+
+    def duplicate_envelope(self, envelope_id: str) -> Awaitable[Envelope]:
+        return to_async(super().duplicate_envelope)(envelope_id)
+
+    def void_envelope(self, envelope_id: str) -> Awaitable[Envelope]:
+        return to_async(super().void_envelope)(envelope_id)
+
+    def rename_envelope(
+        self, request_body: RenameEnvelopeRequest, envelope_id: str
+    ) -> Awaitable[Envelope]:
+        return to_async(super().rename_envelope)(request_body, envelope_id)
+
+    def set_envelope_comment(
+        self, request_body: SetEnvelopeCommentRequest, envelope_id: str
+    ) -> Awaitable[Envelope]:
+        return to_async(super().set_envelope_comment)(request_body, envelope_id)
+
+    def set_envelope_notification(
+        self, request_body: EnvelopeNotification, envelope_id: str
+    ) -> Awaitable[Envelope]:
+        return to_async(super().set_envelope_notification)(request_body, envelope_id)
+
+    def set_envelope_expiration_date(
+        self, request_body: SetEnvelopeExpirationRequest, envelope_id: str
+    ) -> Awaitable[Envelope]:
+        return to_async(super().set_envelope_expiration_date)(request_body, envelope_id)
+
+    def set_envelope_legality_level(
+        self, request_body: SetEnvelopeLegalityLevelRequest, envelope_id: str
+    ) -> Awaitable[Envelope]:
+        return to_async(super().set_envelope_legality_level)(request_body, envelope_id)
+
+    def get_envelope_annotations(self, envelope_id: str) -> Awaitable[List[Annotation]]:
+        return to_async(super().get_envelope_annotations)(envelope_id)
+
+    def get_envelope_document_annotations(
+        self, envelope_id: str, document_id: str
+    ) -> Awaitable[ListEnvelopeDocumentAnnotationsResponse]:
+        return to_async(super().get_envelope_document_annotations)(
+            envelope_id, document_id
+        )
+
+    def add_envelope_annotation(
+        self, request_body: AddAnnotationRequest, envelope_id: str
+    ) -> Awaitable[Annotation]:
+        return to_async(super().add_envelope_annotation)(request_body, envelope_id)
+
+    def delete_envelope_annotation(
+        self, envelope_id: str, annotation_id: str
+    ) -> Awaitable[None]:
+        return to_async(super().delete_envelope_annotation)(envelope_id, annotation_id)
+
+    def create_template(
+        self, request_body: CreateTemplateRequest
+    ) -> Awaitable[Template]:
+        return to_async(super().create_template)(request_body)
+
+    def list_templates(
+        self, request_body: ListTemplatesRequest = None
+    ) -> Awaitable[ListTemplatesResponse]:
+        return to_async(super().list_templates)(request_body)
+
+    def get_template(self, template_id: str) -> Awaitable[Template]:
+        return to_async(super().get_template)(template_id)
+
+    def delete_template(self, template_id: str) -> Awaitable[None]:
+        return to_async(super().delete_template)(template_id)
+
+    def duplicate_template(self, template_id: str) -> Awaitable[Template]:
+        return to_async(super().duplicate_template)(template_id)
+
+    def add_template_document(
+        self, request_body: AddTemplateDocumentRequest, template_id: str
+    ) -> Awaitable[Document]:
+        return to_async(super().add_template_document)(request_body, template_id)
+
+    def get_template_document(
+        self, template_id: str, document_id: str
+    ) -> Awaitable[Document]:
+        return to_async(super().get_template_document)(template_id, document_id)
+
+    def get_template_documents(
+        self, template_id: str
+    ) -> Awaitable[ListTemplateDocumentsResponse]:
+        return to_async(super().get_template_documents)(template_id)
+
+    def add_template_signing_steps(
+        self, request_body: AddTemplateSigningStepsRequest, template_id: str
+    ) -> Awaitable[Template]:
+        return to_async(super().add_template_signing_steps)(request_body, template_id)
+
+    def rename_template(
+        self, request_body: RenameTemplateRequest, template_id: str
+    ) -> Awaitable[Template]:
+        return to_async(super().rename_template)(request_body, template_id)
+
+    def set_template_comment(
+        self, request_body: SetTemplateCommentRequest, template_id: str
+    ) -> Awaitable[Template]:
+        return to_async(super().set_template_comment)(request_body, template_id)
+
+    def set_template_notification(
+        self, request_body: EnvelopeNotification, template_id: str
+    ) -> Awaitable[Template]:
+        return to_async(super().set_template_notification)(request_body, template_id)
+
+    def get_template_annotations(
+        self, template_id: str
+    ) -> Awaitable[ListTemplateAnnotationsResponse]:
+        return to_async(super().get_template_annotations)(template_id)
+
+    def get_document_template_annotations(
+        self, template_id: str, document_id: str
+    ) -> Awaitable[ListTemplateDocumentAnnotationsResponse]:
+        return to_async(super().get_document_template_annotations)(
+            template_id, document_id
+        )
+
+    def add_template_annotation(
+        self, request_body: AddAnnotationRequest, template_id: str
+    ) -> Awaitable[Annotation]:
+        return to_async(super().add_template_annotation)(request_body, template_id)
+
+    def delete_template_annotation(
+        self, template_id: str, annotation_id: str
+    ) -> Awaitable[None]:
+        return to_async(super().delete_template_annotation)(template_id, annotation_id)
+
+    def create_webhook(self, request_body: CreateWebhookRequest) -> Awaitable[Webhook]:
+        return to_async(super().create_webhook)(request_body)
+
+    def list_webhooks(
+        self, request_body: ListWebhooksRequest = None
+    ) -> Awaitable[ListWebhooksResponse]:
+        return to_async(super().list_webhooks)(request_body)
+
+    def delete_webhook(self, webhook_id: str) -> Awaitable[None]:
+        return to_async(super().delete_webhook)(webhook_id)

--- a/src/signplus/services/signplus.py
+++ b/src/signplus/services/signplus.py
@@ -2,6 +2,8 @@ from typing import List
 from .utils.validator import Validator
 from .utils.base_service import BaseService
 from ..net.transport.serializer import Serializer
+from ..net.environment.environment import Environment
+from ..models.utils.sentinel import SENTINEL
 from ..models.utils.cast_models import cast_models
 from ..models import (
     AddAnnotationRequest,
@@ -58,7 +60,10 @@ class SignplusService(BaseService):
         Validator(CreateEnvelopeRequest).validate(request_body)
 
         serialized_request = (
-            Serializer(f"{self.base_url}/envelope", self.get_default_headers())
+            Serializer(
+                f"{self.base_url or Environment.DEFAULT.url}/envelope",
+                [self.get_access_token()],
+            )
             .serialize()
             .set_method("POST")
             .set_body(request_body)
@@ -89,8 +94,8 @@ class SignplusService(BaseService):
 
         serialized_request = (
             Serializer(
-                f"{self.base_url}/envelope/from_template/{{template_id}}",
-                self.get_default_headers(),
+                f"{self.base_url or Environment.DEFAULT.url}/envelope/from_template/{{template_id}}",
+                [self.get_access_token()],
             )
             .add_path("template_id", template_id)
             .serialize()
@@ -119,7 +124,10 @@ class SignplusService(BaseService):
         Validator(ListEnvelopesRequest).is_optional().validate(request_body)
 
         serialized_request = (
-            Serializer(f"{self.base_url}/envelopes", self.get_default_headers())
+            Serializer(
+                f"{self.base_url or Environment.DEFAULT.url}/envelopes",
+                [self.get_access_token()],
+            )
             .serialize()
             .set_method("POST")
             .set_body(request_body)
@@ -145,7 +153,8 @@ class SignplusService(BaseService):
 
         serialized_request = (
             Serializer(
-                f"{self.base_url}/envelope/{{envelope_id}}", self.get_default_headers()
+                f"{self.base_url or Environment.DEFAULT.url}/envelope/{{envelope_id}}",
+                [self.get_access_token()],
             )
             .add_path("envelope_id", envelope_id)
             .serialize()
@@ -170,7 +179,8 @@ class SignplusService(BaseService):
 
         serialized_request = (
             Serializer(
-                f"{self.base_url}/envelope/{{envelope_id}}", self.get_default_headers()
+                f"{self.base_url or Environment.DEFAULT.url}/envelope/{{envelope_id}}",
+                [self.get_access_token()],
             )
             .add_path("envelope_id", envelope_id)
             .serialize()
@@ -178,6 +188,68 @@ class SignplusService(BaseService):
         )
 
         self.send_request(serialized_request)
+
+    @cast_models
+    def download_envelope_signed_documents(
+        self, envelope_id: str, certificate_of_completion: bool = SENTINEL
+    ) -> any:
+        """Download signed documents for an envelope
+
+        :param envelope_id: ID of the envelope
+        :type envelope_id: str
+        :param certificate_of_completion: Whether to include the certificate of completion in the downloaded file, defaults to None
+        :type certificate_of_completion: bool, optional
+        ...
+        :raises RequestError: Raised when a request fails, with optional HTTP status code and details.
+        ...
+        :return: The parsed response data.
+        :rtype: any
+        """
+
+        Validator(str).validate(envelope_id)
+        Validator(bool).is_optional().validate(certificate_of_completion)
+
+        serialized_request = (
+            Serializer(
+                f"{self.base_url or Environment.DEFAULT.url}/envelope/{{envelope_id}}/signed_documents",
+                [self.get_access_token()],
+            )
+            .add_path("envelope_id", envelope_id)
+            .add_query("certificate_of_completion", certificate_of_completion)
+            .serialize()
+            .set_method("GET")
+        )
+
+        response, _, _ = self.send_request(serialized_request)
+        return response
+
+    @cast_models
+    def download_envelope_certificate(self, envelope_id: str) -> any:
+        """Download certificate of completion for an envelope
+
+        :param envelope_id: ID of the envelope
+        :type envelope_id: str
+        ...
+        :raises RequestError: Raised when a request fails, with optional HTTP status code and details.
+        ...
+        :return: The parsed response data.
+        :rtype: any
+        """
+
+        Validator(str).validate(envelope_id)
+
+        serialized_request = (
+            Serializer(
+                f"{self.base_url or Environment.DEFAULT.url}/envelope/{{envelope_id}}/certificate",
+                [self.get_access_token()],
+            )
+            .add_path("envelope_id", envelope_id)
+            .serialize()
+            .set_method("GET")
+        )
+
+        response, _, _ = self.send_request(serialized_request)
+        return response
 
     @cast_models
     def get_envelope_document(self, envelope_id: str, document_id: str) -> Document:
@@ -199,8 +271,8 @@ class SignplusService(BaseService):
 
         serialized_request = (
             Serializer(
-                f"{self.base_url}/envelope/{{envelope_id}}/document/{{document_id}}",
-                self.get_default_headers(),
+                f"{self.base_url or Environment.DEFAULT.url}/envelope/{{envelope_id}}/document/{{document_id}}",
+                [self.get_access_token()],
             )
             .add_path("envelope_id", envelope_id)
             .add_path("document_id", document_id)
@@ -228,8 +300,8 @@ class SignplusService(BaseService):
 
         serialized_request = (
             Serializer(
-                f"{self.base_url}/envelope/{{envelope_id}}/documents",
-                self.get_default_headers(),
+                f"{self.base_url or Environment.DEFAULT.url}/envelope/{{envelope_id}}/documents",
+                [self.get_access_token()],
             )
             .add_path("envelope_id", envelope_id)
             .serialize()
@@ -261,8 +333,8 @@ class SignplusService(BaseService):
 
         serialized_request = (
             Serializer(
-                f"{self.base_url}/envelope/{{envelope_id}}/document",
-                self.get_default_headers(),
+                f"{self.base_url or Environment.DEFAULT.url}/envelope/{{envelope_id}}/document",
+                [self.get_access_token()],
             )
             .add_path("envelope_id", envelope_id)
             .serialize()
@@ -295,8 +367,8 @@ class SignplusService(BaseService):
 
         serialized_request = (
             Serializer(
-                f"{self.base_url}/envelope/{{envelope_id}}/dynamic_fields",
-                self.get_default_headers(),
+                f"{self.base_url or Environment.DEFAULT.url}/envelope/{{envelope_id}}/dynamic_fields",
+                [self.get_access_token()],
             )
             .add_path("envelope_id", envelope_id)
             .serialize()
@@ -329,8 +401,8 @@ class SignplusService(BaseService):
 
         serialized_request = (
             Serializer(
-                f"{self.base_url}/envelope/{{envelope_id}}/signing_steps",
-                self.get_default_headers(),
+                f"{self.base_url or Environment.DEFAULT.url}/envelope/{{envelope_id}}/signing_steps",
+                [self.get_access_token()],
             )
             .add_path("envelope_id", envelope_id)
             .serialize()
@@ -358,8 +430,8 @@ class SignplusService(BaseService):
 
         serialized_request = (
             Serializer(
-                f"{self.base_url}/envelope/{{envelope_id}}/send",
-                self.get_default_headers(),
+                f"{self.base_url or Environment.DEFAULT.url}/envelope/{{envelope_id}}/send",
+                [self.get_access_token()],
             )
             .add_path("envelope_id", envelope_id)
             .serialize()
@@ -386,8 +458,8 @@ class SignplusService(BaseService):
 
         serialized_request = (
             Serializer(
-                f"{self.base_url}/envelope/{{envelope_id}}/duplicate",
-                self.get_default_headers(),
+                f"{self.base_url or Environment.DEFAULT.url}/envelope/{{envelope_id}}/duplicate",
+                [self.get_access_token()],
             )
             .add_path("envelope_id", envelope_id)
             .serialize()
@@ -414,8 +486,8 @@ class SignplusService(BaseService):
 
         serialized_request = (
             Serializer(
-                f"{self.base_url}/envelope/{{envelope_id}}/void",
-                self.get_default_headers(),
+                f"{self.base_url or Environment.DEFAULT.url}/envelope/{{envelope_id}}/void",
+                [self.get_access_token()],
             )
             .add_path("envelope_id", envelope_id)
             .serialize()
@@ -447,8 +519,8 @@ class SignplusService(BaseService):
 
         serialized_request = (
             Serializer(
-                f"{self.base_url}/envelope/{{envelope_id}}/rename",
-                self.get_default_headers(),
+                f"{self.base_url or Environment.DEFAULT.url}/envelope/{{envelope_id}}/rename",
+                [self.get_access_token()],
             )
             .add_path("envelope_id", envelope_id)
             .serialize()
@@ -481,8 +553,8 @@ class SignplusService(BaseService):
 
         serialized_request = (
             Serializer(
-                f"{self.base_url}/envelope/{{envelope_id}}/set_comment",
-                self.get_default_headers(),
+                f"{self.base_url or Environment.DEFAULT.url}/envelope/{{envelope_id}}/set_comment",
+                [self.get_access_token()],
             )
             .add_path("envelope_id", envelope_id)
             .serialize()
@@ -515,8 +587,8 @@ class SignplusService(BaseService):
 
         serialized_request = (
             Serializer(
-                f"{self.base_url}/envelope/{{envelope_id}}/set_notification",
-                self.get_default_headers(),
+                f"{self.base_url or Environment.DEFAULT.url}/envelope/{{envelope_id}}/set_notification",
+                [self.get_access_token()],
             )
             .add_path("envelope_id", envelope_id)
             .serialize()
@@ -549,8 +621,8 @@ class SignplusService(BaseService):
 
         serialized_request = (
             Serializer(
-                f"{self.base_url}/envelope/{{envelope_id}}/set_expiration_date",
-                self.get_default_headers(),
+                f"{self.base_url or Environment.DEFAULT.url}/envelope/{{envelope_id}}/set_expiration_date",
+                [self.get_access_token()],
             )
             .add_path("envelope_id", envelope_id)
             .serialize()
@@ -583,8 +655,8 @@ class SignplusService(BaseService):
 
         serialized_request = (
             Serializer(
-                f"{self.base_url}/envelope/{{envelope_id}}/set_legality_level",
-                self.get_default_headers(),
+                f"{self.base_url or Environment.DEFAULT.url}/envelope/{{envelope_id}}/set_legality_level",
+                [self.get_access_token()],
             )
             .add_path("envelope_id", envelope_id)
             .serialize()
@@ -612,8 +684,8 @@ class SignplusService(BaseService):
 
         serialized_request = (
             Serializer(
-                f"{self.base_url}/envelope/{{envelope_id}}/annotations",
-                self.get_default_headers(),
+                f"{self.base_url or Environment.DEFAULT.url}/envelope/{{envelope_id}}/annotations",
+                [self.get_access_token()],
             )
             .add_path("envelope_id", envelope_id)
             .serialize()
@@ -645,8 +717,8 @@ class SignplusService(BaseService):
 
         serialized_request = (
             Serializer(
-                f"{self.base_url}/envelope/{{envelope_id}}/annotations/{{document_id}}",
-                self.get_default_headers(),
+                f"{self.base_url or Environment.DEFAULT.url}/envelope/{{envelope_id}}/annotations/{{document_id}}",
+                [self.get_access_token()],
             )
             .add_path("envelope_id", envelope_id)
             .add_path("document_id", document_id)
@@ -679,8 +751,8 @@ class SignplusService(BaseService):
 
         serialized_request = (
             Serializer(
-                f"{self.base_url}/envelope/{{envelope_id}}/annotation",
-                self.get_default_headers(),
+                f"{self.base_url or Environment.DEFAULT.url}/envelope/{{envelope_id}}/annotation",
+                [self.get_access_token()],
             )
             .add_path("envelope_id", envelope_id)
             .serialize()
@@ -709,8 +781,8 @@ class SignplusService(BaseService):
 
         serialized_request = (
             Serializer(
-                f"{self.base_url}/envelope/{{envelope_id}}/annotation/{{annotation_id}}",
-                self.get_default_headers(),
+                f"{self.base_url or Environment.DEFAULT.url}/envelope/{{envelope_id}}/annotation/{{annotation_id}}",
+                [self.get_access_token()],
             )
             .add_path("envelope_id", envelope_id)
             .add_path("annotation_id", annotation_id)
@@ -736,7 +808,10 @@ class SignplusService(BaseService):
         Validator(CreateTemplateRequest).validate(request_body)
 
         serialized_request = (
-            Serializer(f"{self.base_url}/template", self.get_default_headers())
+            Serializer(
+                f"{self.base_url or Environment.DEFAULT.url}/template",
+                [self.get_access_token()],
+            )
             .serialize()
             .set_method("POST")
             .set_body(request_body)
@@ -763,7 +838,10 @@ class SignplusService(BaseService):
         Validator(ListTemplatesRequest).is_optional().validate(request_body)
 
         serialized_request = (
-            Serializer(f"{self.base_url}/templates", self.get_default_headers())
+            Serializer(
+                f"{self.base_url or Environment.DEFAULT.url}/templates",
+                [self.get_access_token()],
+            )
             .serialize()
             .set_method("POST")
             .set_body(request_body)
@@ -789,7 +867,8 @@ class SignplusService(BaseService):
 
         serialized_request = (
             Serializer(
-                f"{self.base_url}/template/{{template_id}}", self.get_default_headers()
+                f"{self.base_url or Environment.DEFAULT.url}/template/{{template_id}}",
+                [self.get_access_token()],
             )
             .add_path("template_id", template_id)
             .serialize()
@@ -814,7 +893,8 @@ class SignplusService(BaseService):
 
         serialized_request = (
             Serializer(
-                f"{self.base_url}/template/{{template_id}}", self.get_default_headers()
+                f"{self.base_url or Environment.DEFAULT.url}/template/{{template_id}}",
+                [self.get_access_token()],
             )
             .add_path("template_id", template_id)
             .serialize()
@@ -840,8 +920,8 @@ class SignplusService(BaseService):
 
         serialized_request = (
             Serializer(
-                f"{self.base_url}/template/{{template_id}}/duplicate",
-                self.get_default_headers(),
+                f"{self.base_url or Environment.DEFAULT.url}/template/{{template_id}}/duplicate",
+                [self.get_access_token()],
             )
             .add_path("template_id", template_id)
             .serialize()
@@ -873,8 +953,8 @@ class SignplusService(BaseService):
 
         serialized_request = (
             Serializer(
-                f"{self.base_url}/template/{{template_id}}/document",
-                self.get_default_headers(),
+                f"{self.base_url or Environment.DEFAULT.url}/template/{{template_id}}/document",
+                [self.get_access_token()],
             )
             .add_path("template_id", template_id)
             .serialize()
@@ -905,8 +985,8 @@ class SignplusService(BaseService):
 
         serialized_request = (
             Serializer(
-                f"{self.base_url}/template/{{template_id}}/document/{{document_id}}",
-                self.get_default_headers(),
+                f"{self.base_url or Environment.DEFAULT.url}/template/{{template_id}}/document/{{document_id}}",
+                [self.get_access_token()],
             )
             .add_path("template_id", template_id)
             .add_path("document_id", document_id)
@@ -934,8 +1014,8 @@ class SignplusService(BaseService):
 
         serialized_request = (
             Serializer(
-                f"{self.base_url}/template/{{template_id}}/documents",
-                self.get_default_headers(),
+                f"{self.base_url or Environment.DEFAULT.url}/template/{{template_id}}/documents",
+                [self.get_access_token()],
             )
             .add_path("template_id", template_id)
             .serialize()
@@ -967,8 +1047,8 @@ class SignplusService(BaseService):
 
         serialized_request = (
             Serializer(
-                f"{self.base_url}/template/{{template_id}}/signing_steps",
-                self.get_default_headers(),
+                f"{self.base_url or Environment.DEFAULT.url}/template/{{template_id}}/signing_steps",
+                [self.get_access_token()],
             )
             .add_path("template_id", template_id)
             .serialize()
@@ -1001,8 +1081,8 @@ class SignplusService(BaseService):
 
         serialized_request = (
             Serializer(
-                f"{self.base_url}/template/{{template_id}}/rename",
-                self.get_default_headers(),
+                f"{self.base_url or Environment.DEFAULT.url}/template/{{template_id}}/rename",
+                [self.get_access_token()],
             )
             .add_path("template_id", template_id)
             .serialize()
@@ -1035,8 +1115,8 @@ class SignplusService(BaseService):
 
         serialized_request = (
             Serializer(
-                f"{self.base_url}/template/{{template_id}}/set_comment",
-                self.get_default_headers(),
+                f"{self.base_url or Environment.DEFAULT.url}/template/{{template_id}}/set_comment",
+                [self.get_access_token()],
             )
             .add_path("template_id", template_id)
             .serialize()
@@ -1069,8 +1149,8 @@ class SignplusService(BaseService):
 
         serialized_request = (
             Serializer(
-                f"{self.base_url}/template/{{template_id}}/set_notification",
-                self.get_default_headers(),
+                f"{self.base_url or Environment.DEFAULT.url}/template/{{template_id}}/set_notification",
+                [self.get_access_token()],
             )
             .add_path("template_id", template_id)
             .serialize()
@@ -1100,8 +1180,8 @@ class SignplusService(BaseService):
 
         serialized_request = (
             Serializer(
-                f"{self.base_url}/template/{{template_id}}/annotations",
-                self.get_default_headers(),
+                f"{self.base_url or Environment.DEFAULT.url}/template/{{template_id}}/annotations",
+                [self.get_access_token()],
             )
             .add_path("template_id", template_id)
             .serialize()
@@ -1133,8 +1213,8 @@ class SignplusService(BaseService):
 
         serialized_request = (
             Serializer(
-                f"{self.base_url}/template/{{template_id}}/annotations/{{document_id}}",
-                self.get_default_headers(),
+                f"{self.base_url or Environment.DEFAULT.url}/template/{{template_id}}/annotations/{{document_id}}",
+                [self.get_access_token()],
             )
             .add_path("template_id", template_id)
             .add_path("document_id", document_id)
@@ -1167,8 +1247,8 @@ class SignplusService(BaseService):
 
         serialized_request = (
             Serializer(
-                f"{self.base_url}/template/{{template_id}}/annotation",
-                self.get_default_headers(),
+                f"{self.base_url or Environment.DEFAULT.url}/template/{{template_id}}/annotation",
+                [self.get_access_token()],
             )
             .add_path("template_id", template_id)
             .serialize()
@@ -1197,8 +1277,8 @@ class SignplusService(BaseService):
 
         serialized_request = (
             Serializer(
-                f"{self.base_url}/template/{{template_id}}/annotation/{{annotation_id}}",
-                self.get_default_headers(),
+                f"{self.base_url or Environment.DEFAULT.url}/template/{{template_id}}/annotation/{{annotation_id}}",
+                [self.get_access_token()],
             )
             .add_path("template_id", template_id)
             .add_path("annotation_id", annotation_id)
@@ -1224,7 +1304,10 @@ class SignplusService(BaseService):
         Validator(CreateWebhookRequest).validate(request_body)
 
         serialized_request = (
-            Serializer(f"{self.base_url}/webhook", self.get_default_headers())
+            Serializer(
+                f"{self.base_url or Environment.DEFAULT.url}/webhook",
+                [self.get_access_token()],
+            )
             .serialize()
             .set_method("POST")
             .set_body(request_body)
@@ -1251,7 +1334,10 @@ class SignplusService(BaseService):
         Validator(ListWebhooksRequest).is_optional().validate(request_body)
 
         serialized_request = (
-            Serializer(f"{self.base_url}/webhooks", self.get_default_headers())
+            Serializer(
+                f"{self.base_url or Environment.DEFAULT.url}/webhooks",
+                [self.get_access_token()],
+            )
             .serialize()
             .set_method("POST")
             .set_body(request_body)
@@ -1275,7 +1361,8 @@ class SignplusService(BaseService):
 
         serialized_request = (
             Serializer(
-                f"{self.base_url}/webhook/{{webhook_id}}", self.get_default_headers()
+                f"{self.base_url or Environment.DEFAULT.url}/webhook/{{webhook_id}}",
+                [self.get_access_token()],
             )
             .add_path("webhook_id", webhook_id)
             .serialize()

--- a/src/signplus/services/utils/base_service.py
+++ b/src/signplus/services/utils/base_service.py
@@ -2,6 +2,9 @@ from typing import Any, Dict, Tuple, Generator
 from enum import Enum
 
 from .default_headers import DefaultHeaders, DefaultHeadersKeys
+
+from ...net.headers.base_header import BaseHeader
+
 from ...net.transport.request import Request
 from ...net.request_chain.request_chain import RequestChain
 from ...net.request_chain.handlers.hook_handler import HookHandler
@@ -39,6 +42,15 @@ class BaseService:
         )
 
         return self
+
+    def get_access_token(self) -> BaseHeader:
+        """
+        Get the access auth header.
+
+        :return: The access auth header.
+        :rtype: BaseHeader
+        """
+        return self._default_headers.get_header(DefaultHeadersKeys.ACCESS_AUTH)
 
     def set_timeout(self, timeout: int):
         """
@@ -110,8 +122,8 @@ class BaseService:
         """
         return (
             RequestChain()
-            .add_handler(RetryHandler())
             .add_handler(HookHandler())
+            .add_handler(RetryHandler())
             .add_handler(HttpHandler(self._timeout))
         )
 

--- a/src/signplus/services/utils/validator.py
+++ b/src/signplus/services/utils/validator.py
@@ -1,19 +1,25 @@
 import re
 import operator
 from typing import Union, Any, Type, Pattern, get_args
+from ...models.utils.sentinel import was_value_set
 from ...models.utils.one_of_base_model import OneOfBaseModel
 
 
 class Validator:
     """
-    A simple validator class for validating the type and pattern of a value.
+    A simple validator class for validating the type, pattern, and other constraints of a value.
 
     :ivar Type[Any] _type: The expected type for the value.
     :ivar bool _is_optional: Flag indicating whether the value is optional.
+    :ivar bool _is_nullable: Flag indicating whether the value can be null.
     :ivar bool _is_array: Flag indicating whether the value is an array.
     :ivar Pattern[str] _pattern: The regular expression pattern for validating the value.
+    :ivar int _min_length: The minimum length for validating the value.
+    :ivar int _max_length: The maximum length for validating the value.
     :ivar int _min: The minimum value for validating the value.
+    :ivar bool _min_exclusive: Flag indicating whether the minimum value is exclusive.
     :ivar int _max: The maximum value for validating the value.
+    :ivar bool _max_exclusive: Flag indicating whether the maximum value is exclusive.
     """
 
     def __init__(self, _type: Type[Any] = None):
@@ -24,6 +30,7 @@ class Validator:
         """
         self._type: Type[Any] = _type
         self._is_optional: bool = False
+        self._is_nullable: bool = False
         self._is_array: bool = False
         self._pattern: Pattern[str] = None
         self._min_length: int = None
@@ -51,6 +58,16 @@ class Validator:
         :rtype: Validator
         """
         self._is_optional = True
+        return self
+
+    def is_nullable(self) -> "Validator":
+        """
+        Marks the value as nullable.
+
+        :return: The Validator instance for method chaining.
+        :rtype: Validator
+        """
+        self._is_nullable = True
         return self
 
     def pattern(self, pattern: str) -> "Validator":
@@ -121,7 +138,11 @@ class Validator:
         """
         if not self._type:
             raise TypeError("Invalid type: No type specified")
-        if self._is_optional and value is None:
+
+        if self._is_nullable and value is None:
+            return
+
+        if self._is_optional and not was_value_set(value):
             return
 
         self._validate_type(value)
@@ -148,7 +169,11 @@ class Validator:
         :param Any value: The input that needs to be checked
         :raises ValueError: If the value does not match the oneOf rules.
         """
-        class_list = {arg.__name__: arg for arg in get_args(self._type) if arg.__name__}
+        class_list = {
+            arg.__name__: arg
+            for arg in get_args(self._type)
+            if hasattr(arg, "__name__")
+        }
         OneOfBaseModel.class_list = class_list
         OneOfBaseModel.return_one_of(value)
 


### PR DESCRIPTION
**Introducing ID verification**

Added a new recipient verification method, `ID_VERIFICATION`, allowing for an automated ID and selfie check before the recipient can access the envelope.
The value parameter must be left empty when using `ID_VERIFICATION`; existing rules for `PASSCODE` and `SMS` remain unchanged.